### PR TITLE
fix(hooks): normalize-line-endings now outputs {} when no action needed

### DIFF
--- a/hooks/normalize-line-endings.py
+++ b/hooks/normalize-line-endings.py
@@ -24,8 +24,13 @@ try:
             }
         }
         print(json.dumps(output))
+    else:
+        # No action needed - output empty JSON
+        print(json.dumps({}))
 
     sys.exit(0)
 
 except Exception:
+    # On error, output empty JSON as per hook guidelines
+    print(json.dumps({}))
     sys.exit(1)


### PR DESCRIPTION
Fixes the normalize-line-endings.py hook to output `{}` when no action is needed, as per hook development guidelines.

## Changes
- Added else clause to output `{}` when no line ending normalization is required
- Added `{}` output on exception as per hook guidelines

## Testing
Manually tested both cases:
- With no CRLF: outputs `{}`
- With CRLF/CR: outputs proper normalization response