### PR TITLE
fix(hooks): ensure all hooks output valid JSON per guidelines

### DIFF
--- a/hooks/auto-unsandbox-pbcopy.py
+++ b/hooks/auto-unsandbox-pbcopy.py
@@ -31,8 +31,13 @@ try:
             }
         }
         print(json.dumps(output))
+    else:
+        # No action needed, output empty JSON as per hook guidelines
+        print(json.dumps({}))
 
     sys.exit(0)
 
 except Exception:
+    # On error, output empty JSON as per hook guidelines
+    print(json.dumps({}))
     sys.exit(1)

--- a/hooks/detect-heredoc-errors.py
+++ b/hooks/detect-heredoc-errors.py
@@ -63,4 +63,9 @@ IMPORTANT: Heredocs don't work in sandbox mode. Use one of the above alternative
     sys.exit(0)
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        # On error, output empty JSON as per hook guidelines
+        print(json.dumps({}))
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- Fixed `auto-unsandbox-pbcopy.py` to output `{}` when no action needed (both in else branch and exception handler)
- Fixed `detect-heredoc-errors.py` to include try-except block for error handling
- Both hooks now comply with guidelines in `hooks/README.md`

## Details

### auto-unsandbox-pbcopy.py
This hook had the same issue as `normalize-line-endings.py` (fixed in PR #14):
- Missing `{}` output when `pbcopy` not in command
- Exception handler didn't output `{}` before exit

Now outputs empty JSON in both cases per hook guidelines.

### detect-heredoc-errors.py
Missing try-except block as required by guidelines:
- Added try-except wrapper around main() execution
- Outputs `{}` on any exception
- Consistent with error handling pattern in other hooks

## Testing

### auto-unsandbox-pbcopy.py
```bash
# Test with pbcopy command (should output permission JSON)
echo '{"tool_name":"Bash","tool_input":{"command":"echo test | pbcopy"}}' | python3 hooks/auto-unsandbox-pbcopy.py

# Test without pbcopy (should output {})
echo '{"tool_name":"Bash","tool_input":{"command":"echo test"}}' | python3 hooks/auto-unsandbox-pbcopy.py
```

### detect-heredoc-errors.py
```bash
# Test with heredoc error (should output guidance)
echo '{"tool_name":"Bash","error":"can't create temp file for here document: Read-only file system"}' | python3 hooks/detect-heredoc-errors.py

# Test without error (should output {})
echo '{"tool_name":"Bash"}' | python3 hooks/detect-heredoc-errors.py
```

## Related Issues

These fixes address consistency issues identified during repository evaluation. Created issue #15 to track development of automated hook validation/linter to prevent similar issues in the future.

Related: #15