### PR TITLE
Fix standalone cd detection in detect-cd-pattern hook

### DIFF
--- a/hooks/detect-cd-pattern.py
+++ b/hooks/detect-cd-pattern.py
@@ -47,7 +47,7 @@ def main():
 
     # Now check for non-subshell cd patterns (the BAD ones)
     cd_patterns = [
-        r'(?:^|;|\||&&)\s*cd(?:\s+|$)',  # cd at start or after separator (with args or standalone)
+        r'(?:^|;|\||&&)\s*cd(?:\s+|$|(?=;|\||&&))',  # cd at start or after separator (with args, standalone, or before separator)
     ]
 
     has_cd = any(re.search(pattern, command) for pattern in cd_patterns)

--- a/hooks/tests/test_detect_cd_pattern.py
+++ b/hooks/tests/test_detect_cd_pattern.py
@@ -187,6 +187,21 @@ class TestDetectCdPattern:
         output = run_hook("Bash", "cd")
         assert "hookSpecificOutput" in output, "cd with no args should trigger (changes to home)"
 
+    def test_cd_no_args_followed_by_semicolon(self):
+        """cd followed by semicolon (no space) should trigger warning"""
+        output = run_hook("Bash", "cd;echo test")
+        assert "hookSpecificOutput" in output, "cd; should trigger"
+
+    def test_cd_no_args_followed_by_ampersand(self):
+        """cd followed by && (no space) should trigger warning"""
+        output = run_hook("Bash", "cd&&echo test")
+        assert "hookSpecificOutput" in output, "cd&& should trigger"
+
+    def test_cd_no_args_followed_by_pipe(self):
+        """cd followed by pipe (no space) should trigger warning"""
+        output = run_hook("Bash", "cd|grep test")
+        assert "hookSpecificOutput" in output, "cd| should trigger"
+
     def test_cd_with_double_dot(self):
         """cd .. should trigger warning"""
         output = run_hook("Bash", "cd ..")


### PR DESCRIPTION
## Summary

Fixes a bug in the `detect-cd-pattern.py` hook where standalone `cd` commands (with no arguments) were not being detected and warned about.

## Problem

The hook's regex pattern required at least one whitespace character after `cd`, meaning `cd` with no arguments wasn't matched. Since `cd` without arguments changes to the home directory, it should trigger the same warning as other global cd usage patterns.

The test file even had a TODO comment acknowledging this gap:
```python
# This is actually a bug we should fix!
pass  # TODO: This is a gap - standalone 'cd' should probably warn
```

## Solution

- Updated regex pattern from `r'(?:^|;|\||&&)\s*cd\s+'` to `r'(?:^|;|\||&&)\s*cd(?:\s+|$)'`
  - Changed `\s+` (one or more whitespace) to `(?:\s+|$)` (whitespace+args OR end of string)
- Fixed `test_cd_with_no_args` to assert expected warning behavior instead of passing with TODO

## Testing

All 30 tests in `test_detect_cd_pattern.py` pass, including the newly fixed test that now properly validates standalone `cd` detection.

```
============================== 30 passed in 3.37s ==============================
```

## Impact

- Prevents bugs where `cd` alone changes to home directory without warning
- Improves reliability and completeness of the cd detection hook
- Maintains consistency with the hook's stated purpose