### PR TITLE
fix(hooks): change hook paths from relative to absolute paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -113,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/normalize-line-endings.py"
+            "command": "uv run --script ~/.claude/hooks/normalize-line-endings.py"
           }
         ]
       },
@@ -122,23 +122,23 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/gh-authorship-attribution.py"
+            "command": "uv run --script ~/.claude/hooks/gh-authorship-attribution.py"
           },
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/gh-web-fallback.py"
+            "command": "uv run --script ~/.claude/hooks/gh-web-fallback.py"
           },
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/prefer-modern-tools.py"
+            "command": "uv run --script ~/.claude/hooks/prefer-modern-tools.py"
           },
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/detect-cd-pattern.py"
+            "command": "uv run --script ~/.claude/hooks/detect-cd-pattern.py"
           },
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/auto-unsandbox-pbcopy.py"
+            "command": "uv run --script ~/.claude/hooks/auto-unsandbox-pbcopy.py"
           }
         ]
       },
@@ -147,7 +147,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/prefer-gh-for-own-repos.py"
+            "command": "uv run --script ~/.claude/hooks/prefer-gh-for-own-repos.py"
           }
         ]
       }
@@ -158,11 +158,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/gpg-signing-helper.py"
+            "command": "uv run --script ~/.claude/hooks/gpg-signing-helper.py"
           },
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/detect-heredoc-errors.py",
+            "command": "uv run --script ~/.claude/hooks/detect-heredoc-errors.py",
             "timeout": 10
           }
         ]
@@ -174,20 +174,20 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/gh-fallback-helper.py"
+            "command": "uv run --script ~/.claude/hooks/gh-fallback-helper.py"
           },
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/gpg-signing-helper.py"
+            "command": "uv run --script ~/.claude/hooks/gpg-signing-helper.py"
           },
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/detect-heredoc-errors.py",
+            "command": "uv run --script ~/.claude/hooks/detect-heredoc-errors.py",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "uv run --script .claude/hooks/suggest-uv-for-missing-deps.py"
+            "command": "uv run --script ~/.claude/hooks/suggest-uv-for-missing-deps.py"
           }
         ]
       }


### PR DESCRIPTION
The hooks were using relative paths (.claude/hooks/*.py) which break when the working directory changes (e.g., from running cd or pytest in subdirs). This causes a deadlock where hooks fail and block Write/Edit operations.

Changed all hook paths to use absolute paths (~/.claude/hooks/*.py) which work regardless of current working directory.

Fixes #33