### PR TITLE
Fix pipe edge case in GitHub API hooks

### DIFF
--- a/.claude/hooks/gh-fallback-helper.py
+++ b/.claude/hooks/gh-fallback-helper.py
@@ -104,7 +104,7 @@ def main():
 
 1. **List issues:**
    ```bash
-   curl -s -H "Authorization: token $GITHUB_TOKEN" \\
+   curl -s -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
      -H "Accept: application/vnd.github.v3+json" \\
      "https://api.github.com/repos/OWNER/REPO/issues"
    ```
@@ -112,7 +112,7 @@ def main():
 2. **Create pull request:**
    ```bash
    curl -X POST \\
-     -H "Authorization: token $GITHUB_TOKEN" \\
+     -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
      -H "Accept: application/vnd.github.v3+json" \\
      "https://api.github.com/repos/OWNER/REPO/pulls" \\
      -d '{{"title":"PR Title","head":"branch-name","base":"main","body":"PR description"}}'
@@ -120,7 +120,7 @@ def main():
 
 3. **Get issue/PR details:**
    ```bash
-   curl -s -H "Authorization: token $GITHUB_TOKEN" \\
+   curl -s -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
      -H "Accept: application/vnd.github.v3+json" \\
      "https://api.github.com/repos/OWNER/REPO/issues/NUMBER"
    ```
@@ -128,7 +128,7 @@ def main():
 4. **Update PR/issue:**
    ```bash
    curl -X PATCH \\
-     -H "Authorization: token $GITHUB_TOKEN" \\
+     -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
      -H "Accept: application/vnd.github.v3+json" \\
      "https://api.github.com/repos/OWNER/REPO/pulls/NUMBER" \\
      -d '{{"body":"Updated description"}}'
@@ -136,19 +136,19 @@ def main():
 
 5. **Search issues:**
    ```bash
-   curl -s -H "Authorization: token $GITHUB_TOKEN" \\
+   curl -s -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
      -H "Accept: application/vnd.github.v3+json" \\
      "https://api.github.com/repos/OWNER/REPO/issues?state=all"
    ```
 
 **Tips:**
 - Use `jq` or `python3 -m json.tool` to parse JSON responses
-- The GITHUB_TOKEN is already available as `$GITHUB_TOKEN`
+- Use `$(printenv GITHUB_TOKEN)` instead of `$GITHUB_TOKEN` when using pipes
 - GitHub API docs: https://docs.github.com/en/rest
 
 **Example converting your gh command:**
 If you tried: `gh issue list`
-Use instead: `curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/OWNER/REPO/issues"`"""
+Use instead: `curl -s -H "Authorization: token $(printenv GITHUB_TOKEN)" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/OWNER/REPO/issues"`"""
         }
     }
 

--- a/.claude/hooks/gh-web-fallback.py
+++ b/.claude/hooks/gh-web-fallback.py
@@ -51,12 +51,12 @@ Guidance provided:
 Example patterns:
 ```bash
 # View issue
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
+curl -s -H "Authorization: token $(printenv GITHUB_TOKEN)" \
   -H "Accept: application/vnd.github.v3+json" \
   "https://api.github.com/repos/OWNER/REPO/issues/NUMBER"
 
 # Create PR
-curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
+curl -X POST -H "Authorization: token $(printenv GITHUB_TOKEN)" \
   -H "Accept: application/vnd.github.v3+json" \
   "https://api.github.com/repos/OWNER/REPO/pulls" \
   -d '{"title":"PR Title","head":"branch","base":"main","body":"Description"}'
@@ -203,28 +203,28 @@ def main():
                 "hookEventName": "PreToolUse",
                 "additionalContext": """**ENVIRONMENT NOTICE: Claude Code Web Detected**
 
-The `gh` CLI is not available in this environment, but `$GITHUB_TOKEN` is available.
+The `gh` CLI is not available in this environment, but `GITHUB_TOKEN` is available.
 Use the GitHub REST API with curl instead.
 
 **GitHub API Patterns:**
 
 1. **View issue/PR:**
    ```bash
-   curl -s -H "Authorization: token $GITHUB_TOKEN" \\
+   curl -s -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
      -H "Accept: application/vnd.github.v3+json" \\
      "https://api.github.com/repos/OWNER/REPO/issues/NUMBER"
    ```
 
 2. **List issues:**
    ```bash
-   curl -s -H "Authorization: token $GITHUB_TOKEN" \\
+   curl -s -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
      -H "Accept: application/vnd.github.v3+json" \\
      "https://api.github.com/repos/OWNER/REPO/issues"
    ```
 
 3. **Create pull request:**
    ```bash
-   curl -X POST -H "Authorization: token $GITHUB_TOKEN" \\
+   curl -X POST -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
      -H "Accept: application/vnd.github.v3+json" \\
      "https://api.github.com/repos/OWNER/REPO/pulls" \\
      -d '{"title":"PR Title","head":"branch","base":"main","body":"Description"}'
@@ -232,7 +232,7 @@ Use the GitHub REST API with curl instead.
 
 4. **Check CI status:**
    ```bash
-   curl -s -H "Authorization: token $GITHUB_TOKEN" \\
+   curl -s -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
      -H "Accept: application/vnd.github.v3+json" \\
      "https://api.github.com/repos/OWNER/REPO/commits/SHA/check-runs"
    ```
@@ -240,6 +240,7 @@ Use the GitHub REST API with curl instead.
 **Tips:**
 - Use `-s` flag for silent mode (no progress)
 - Parse JSON with `jq` or `python3 -m json.tool` (never manual string parsing)
+- Use `$(printenv GITHUB_TOKEN)` instead of `$GITHUB_TOKEN` when using pipes
 - GitHub API docs: https://docs.github.com/en/rest
 
 **This message will only appear once per 5 minutes.**"""


### PR DESCRIPTION
## Summary

Fixes #31 by updating GitHub API hooks to use `$(printenv GITHUB_TOKEN)` instead of `$GITHUB_TOKEN` in curl examples.

## The Problem

When using the Bash tool with pipes, shell variable expansion (`$VAR`) evaluates to empty strings. This breaks GitHub API authentication when piping curl output to tools like `jq`:

```bash
# FAILS - $GITHUB_TOKEN expands to empty string
curl -H "Authorization: token $GITHUB_TOKEN" \
  https://api.github.com/user | jq .

# WORKS - $(printenv GITHUB_TOKEN) retrieves the value correctly
curl -H "Authorization: token $(printenv GITHUB_TOKEN)" \
  https://api.github.com/user | jq .
```

## Changes

- **`gh-web-fallback.py`**: Replace `$GITHUB_TOKEN` with `$(printenv GITHUB_TOKEN)` in all curl examples, add tip about using printenv with pipes
- **`gh-fallback-helper.py`**: Same updates for consistency

## Testing

✅ All 72 tests pass (36 for each hook)
- Tests follow "Test Behavior, Not Content" philosophy
- No test updates needed since behavior unchanged, only guidance improved

## Implementation Notes

Kept the fix minimal and subtle:
- Updated curl examples to use the correct syntax
- Added brief tip in each hook explaining when to use `$(printenv VAR)` over `$VAR`
- No additional documentation files or extensive changes needed

The hooks now educate Claude instances about this edge case when they encounter it, without polluting the global configuration.