### PR TITLE
feat(hooks): add CI monitoring reminder hook

### DIFF
--- a/.claude/hooks/monitor-ci-results.py
+++ b/.claude/hooks/monitor-ci-results.py
@@ -1,0 +1,1 @@
+../../plugins/claude-code-hooks/hooks/monitor-ci-results.py

--- a/.claude/hooks/tests/test_monitor_ci_results.py
+++ b/.claude/hooks/tests/test_monitor_ci_results.py
@@ -1,0 +1,351 @@
+"""
+Unit tests for monitor-ci-results.py hook
+
+This test suite validates that the hook properly detects git push and PR creation
+commands and provides CI monitoring guidance when GitHub Actions workflows exist.
+
+Following the testing philosophy: test behavior, not content.
+- Verify that guidance is presented when expected
+- Test trigger conditions (what activates the hook)
+- Validate JSON output structure
+- Don't assert on specific wording in guidance text
+"""
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Path to the hook script
+HOOK_PATH = Path(__file__).parent.parent / "monitor-ci-results.py"
+
+
+def run_hook(
+    tool_name: str,
+    command: str,
+    clear_cooldown: bool = True,
+    has_workflows: bool = True,
+    tool_result: dict = None,
+) -> dict:
+    """
+    Helper function to run the hook.
+
+    Args:
+        tool_name: The name of the tool being used
+        command: The bash command to test
+        clear_cooldown: Whether to clear cooldown state before running
+        has_workflows: Whether to simulate having GitHub workflows
+        tool_result: Optional tool result to include
+
+    Returns:
+        Parsed JSON output from the hook
+    """
+    input_data = {
+        "tool_name": tool_name,
+        "tool_input": {"command": command}
+    }
+
+    if tool_result is not None:
+        input_data["tool_result"] = tool_result
+
+    # Clear cooldown state if requested
+    if clear_cooldown:
+        state_dir = Path.home() / ".claude" / "hook-state"
+        state_file = state_dir / "monitor-ci-cooldown"
+        if state_file.exists():
+            state_file.unlink()
+
+    # Create a temp directory structure to simulate workflows
+    with tempfile.TemporaryDirectory() as tmpdir:
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmpdir)
+
+            if has_workflows:
+                # Create .github/workflows with a sample workflow file
+                workflows_dir = Path(tmpdir) / ".github" / "workflows"
+                workflows_dir.mkdir(parents=True)
+                (workflows_dir / "ci.yml").write_text("name: CI\non: push\njobs: {}")
+
+            result = subprocess.run(
+                ["uv", "run", "--script", str(HOOK_PATH)],
+                input=json.dumps(input_data),
+                capture_output=True,
+                text=True
+            )
+
+            if result.returncode not in [0, 1]:  # 0 = success, 1 = expected error with {}
+                raise RuntimeError(f"Hook failed: {result.stderr}")
+
+            return json.loads(result.stdout)
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestGitPushDetection:
+    """Test git push detection and CI monitoring guidance"""
+
+    def test_git_push_with_workflows_triggers(self):
+        """Git push with workflows should trigger CI monitoring guidance"""
+        output = run_hook("Bash", "git push origin main", has_workflows=True)
+        assert "hookSpecificOutput" in output, "Should detect git push"
+        assert "additionalContext" in output["hookSpecificOutput"]
+        assert len(output["hookSpecificOutput"]["additionalContext"]) > 0, "Should provide guidance"
+
+    def test_git_push_without_workflows_silent(self):
+        """Git push without workflows should not trigger"""
+        output = run_hook("Bash", "git push origin main", has_workflows=False)
+        assert output == {}, "Should not trigger without workflows"
+
+    def test_git_push_with_flags_triggers(self):
+        """Git push with various flags should trigger"""
+        commands = [
+            "git push",
+            "git push origin main",
+            "git push -u origin feature-branch",
+            "git push --force origin main",
+            "git push origin HEAD:refs/heads/branch",
+        ]
+        for cmd in commands:
+            output = run_hook("Bash", cmd, has_workflows=True)
+            assert "hookSpecificOutput" in output, f"Should detect: {cmd}"
+
+    def test_git_push_case_insensitive(self):
+        """Git push detection should be case-insensitive"""
+        for cmd in ["GIT PUSH origin main", "Git Push origin main", "git PUSH origin main"]:
+            output = run_hook("Bash", cmd, has_workflows=True)
+            assert "hookSpecificOutput" in output, f"Should detect: {cmd}"
+
+    def test_chained_git_push_triggers(self):
+        """Git push in chained command should trigger"""
+        output = run_hook("Bash", "git add . && git commit -m 'test' && git push", has_workflows=True)
+        assert "hookSpecificOutput" in output, "Should detect git push in chain"
+
+
+class TestPRCreationDetection:
+    """Test PR creation detection"""
+
+    def test_gh_pr_create_triggers(self):
+        """gh pr create should trigger CI monitoring guidance"""
+        output = run_hook("Bash", 'gh pr create --title "Test" --body "Description"', has_workflows=True)
+        assert "hookSpecificOutput" in output, "Should detect gh pr create"
+        assert "additionalContext" in output["hookSpecificOutput"]
+
+    def test_gh_pr_create_without_workflows_silent(self):
+        """gh pr create without workflows should not trigger"""
+        output = run_hook("Bash", 'gh pr create --title "Test"', has_workflows=False)
+        assert output == {}, "Should not trigger without workflows"
+
+    def test_github_api_pr_create_triggers(self):
+        """curl POST to /pulls should trigger CI monitoring guidance"""
+        command = '''curl -X POST -H "Authorization: token $TOKEN" \
+            "https://api.github.com/repos/owner/repo/pulls" \
+            -d '{"title":"Test","head":"feature","base":"main"}'
+        '''
+        output = run_hook("Bash", command, has_workflows=True)
+        assert "hookSpecificOutput" in output, "Should detect GitHub API PR creation"
+
+    def test_gh_pr_create_variations(self):
+        """Various gh pr create forms should trigger"""
+        commands = [
+            'gh pr create',
+            'gh pr create --title "Test"',
+            'gh pr create --fill',
+            'gh pr create --draft --title "WIP"',
+        ]
+        for cmd in commands:
+            output = run_hook("Bash", cmd, has_workflows=True)
+            assert "hookSpecificOutput" in output, f"Should detect: {cmd}"
+
+
+class TestCooldownMechanism:
+    """Test cooldown mechanism"""
+
+    def test_cooldown_prevents_duplicate_reminders(self):
+        """Reminders should be rate-limited by cooldown"""
+        # First call should trigger
+        output1 = run_hook("Bash", "git push origin main", clear_cooldown=True, has_workflows=True)
+        assert "hookSpecificOutput" in output1, "First call should trigger"
+
+        # Second call within cooldown should not trigger
+        output2 = run_hook("Bash", "git push origin main", clear_cooldown=False, has_workflows=True)
+        assert output2 == {}, "Second call should be suppressed by cooldown"
+
+    def test_cooldown_applies_across_operations(self):
+        """Cooldown should apply to both push and PR create"""
+        # Trigger with git push
+        output1 = run_hook("Bash", "git push origin main", clear_cooldown=True, has_workflows=True)
+        assert "hookSpecificOutput" in output1
+
+        # PR create should also be suppressed
+        output2 = run_hook("Bash", 'gh pr create --title "Test"', clear_cooldown=False, has_workflows=True)
+        assert output2 == {}, "PR create should be suppressed by cooldown"
+
+    def test_cooldown_state_file_created(self):
+        """Cooldown state file should be created"""
+        state_dir = Path.home() / ".claude" / "hook-state"
+        state_file = state_dir / "monitor-ci-cooldown"
+
+        # Clear state first
+        if state_file.exists():
+            state_file.unlink()
+
+        # Trigger hook
+        run_hook("Bash", "git push origin main", clear_cooldown=False, has_workflows=True)
+
+        # Check state file was created
+        assert state_file.exists(), "State file should be created"
+        assert state_file.read_text().strip(), "State file should contain timestamp"
+
+
+class TestNonTriggeringCommands:
+    """Test that non-relevant commands don't trigger"""
+
+    def test_non_bash_tools_silent(self):
+        """Non-Bash tools should not trigger"""
+        tools = ["Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
+        for tool in tools:
+            output = run_hook(tool, "git push origin main", has_workflows=True)
+            assert output == {}, f"{tool} should not trigger hook"
+
+    @pytest.mark.parametrize("command,description", [
+        ("git status", "git status"),
+        ("git add .", "git add"),
+        ("git commit -m 'test'", "git commit"),
+        ("git pull origin main", "git pull"),
+        ("git fetch origin", "git fetch"),
+        ("git log --oneline", "git log"),
+        ("git diff HEAD~1", "git diff"),
+    ])
+    def test_non_push_git_commands_silent(self, command, description):
+        """Non-push git commands should not trigger"""
+        output = run_hook("Bash", command, has_workflows=True)
+        assert output == {}, f"{description} should not trigger"
+
+    @pytest.mark.parametrize("command,description", [
+        ("gh pr list", "pr list"),
+        ("gh pr view 123", "pr view"),
+        ("gh pr checks", "pr checks"),
+        ("gh issue list", "issue list"),
+        ("gh run list", "run list"),
+    ])
+    def test_gh_read_commands_silent(self, command, description):
+        """gh CLI read commands should not trigger"""
+        output = run_hook("Bash", command, has_workflows=True)
+        assert output == {}, f"{description} should not trigger"
+
+    def test_empty_command_silent(self):
+        """Empty command should not trigger"""
+        output = run_hook("Bash", "", has_workflows=True)
+        assert output == {}, "Empty command should not trigger"
+
+
+class TestErrorHandling:
+    """Test behavior when command has errors"""
+
+    def test_command_with_error_silent(self):
+        """Commands that failed should not trigger"""
+        output = run_hook(
+            "Bash",
+            "git push origin main",
+            has_workflows=True,
+            tool_result={"error": "fatal: could not read from remote repository"}
+        )
+        assert output == {}, "Failed command should not trigger CI reminder"
+
+
+class TestWorkflowDetection:
+    """Test GitHub workflow detection"""
+
+    def test_triggers_with_yml_workflow(self):
+        """Should trigger when .github/workflows contains .yml files"""
+        output = run_hook("Bash", "git push origin main", has_workflows=True)
+        assert "hookSpecificOutput" in output, "Should trigger with yml workflow"
+
+    def test_silent_without_workflows_dir(self):
+        """Should not trigger when .github/workflows doesn't exist"""
+        output = run_hook("Bash", "git push origin main", has_workflows=False)
+        assert output == {}, "Should not trigger without workflows directory"
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions"""
+
+    def test_malformed_json_input_returns_empty(self):
+        """Hook should handle malformed JSON gracefully"""
+        result = subprocess.run(
+            ["uv", "run", "--script", str(HOOK_PATH)],
+            input="not valid json",
+            capture_output=True,
+            text=True
+        )
+        # Should exit with error code but output valid JSON
+        output = json.loads(result.stdout)
+        assert output == {}, "Should return {} on malformed input"
+
+    def test_missing_tool_name_returns_empty(self):
+        """Hook should handle missing tool_name field"""
+        input_data = {"tool_input": {"command": "git push origin main"}}
+        result = subprocess.run(
+            ["uv", "run", "--script", str(HOOK_PATH)],
+            input=json.dumps(input_data),
+            capture_output=True,
+            text=True
+        )
+        output = json.loads(result.stdout)
+        assert output == {}, "Should return {} when tool_name missing"
+
+    def test_missing_command_returns_empty(self):
+        """Hook should handle missing command field"""
+        input_data = {"tool_name": "Bash", "tool_input": {}}
+        result = subprocess.run(
+            ["uv", "run", "--script", str(HOOK_PATH)],
+            input=json.dumps(input_data),
+            capture_output=True,
+            text=True
+        )
+        output = json.loads(result.stdout)
+        assert output == {}, "Should return {} when command missing"
+
+
+class TestOutputValidation:
+    """Test output format validation"""
+
+    def test_output_is_valid_json(self):
+        """Hook output should always be valid JSON"""
+        output = run_hook("Bash", "git push origin main", has_workflows=True)
+        # Should be parseable as JSON (already done by run_hook)
+        assert isinstance(output, dict)
+
+    def test_event_name_correct_for_push(self):
+        """Hook should set correct event name for push"""
+        output = run_hook("Bash", "git push origin main", has_workflows=True)
+        if "hookSpecificOutput" in output:
+            assert output["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+
+    def test_event_name_correct_for_pr(self):
+        """Hook should set correct event name for PR create"""
+        output = run_hook("Bash", 'gh pr create --title "Test"', has_workflows=True)
+        if "hookSpecificOutput" in output:
+            assert output["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+
+    def test_push_guidance_presented(self):
+        """Git push should trigger guidance presentation"""
+        output = run_hook("Bash", "git push origin main", has_workflows=True)
+        assert "hookSpecificOutput" in output
+        assert "additionalContext" in output["hookSpecificOutput"]
+        assert len(output["hookSpecificOutput"]["additionalContext"]) > 0
+
+    def test_pr_guidance_presented(self):
+        """PR creation should trigger guidance presentation"""
+        output = run_hook("Bash", 'gh pr create --title "Test"', has_workflows=True)
+        assert "hookSpecificOutput" in output
+        assert "additionalContext" in output["hookSpecificOutput"]
+        assert len(output["hookSpecificOutput"]["additionalContext"]) > 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -160,6 +160,10 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/run-with-fallback.sh open \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/detect-heredoc-errors.py",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/run-with-fallback.sh open \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/monitor-ci-results.py"
           }
         ]
       }

--- a/plugins/claude-code-hooks/hooks/monitor-ci-results.py
+++ b/plugins/claude-code-hooks/hooks/monitor-ci-results.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = []
+# ///
+"""
+monitor-ci-results: Remind Claude to monitor CI results after push or PR creation.
+
+Event: PostToolUse (Bash)
+
+Purpose: After pushing commits or creating pull requests, remind Claude to monitor
+CI results on GitHub so issues can be caught and addressed quickly.
+
+Behavior:
+- Detects successful `git push` commands
+- Detects successful PR creation (via `gh pr create` or curl POST to /pulls)
+- Checks if the repository has GitHub Actions workflows (.github/workflows/)
+- Provides guidance on monitoring CI status using `gh run` or GitHub API
+- Includes 2-minute cooldown to avoid repetitive reminders
+
+Triggers on:
+- `git push` (any successful push to remote)
+- `gh pr create` (PR creation via gh CLI)
+- `curl -X POST .../pulls` (PR creation via GitHub API)
+
+Does NOT trigger when:
+- No CI workflows detected (.github/workflows/ doesn't exist)
+- Within 2-minute cooldown period since last reminder
+- Command failed (error present in output)
+- Non-Bash tools are used
+- Non-push/PR commands
+
+Guidance provided:
+- How to check CI status with `gh run list` and `gh run watch`
+- Alternative GitHub API commands when gh is unavailable
+- Reminder to check PR checks page
+
+Why this matters:
+- CI failures caught early save time and prevent broken main branches
+- Developers can address issues while context is still fresh
+- Proactive monitoring leads to faster feedback loops
+- Helps maintain code quality through automated testing
+
+State management:
+- Cooldown state stored in: `~/.claude/hook-state/monitor-ci-cooldown`
+- Contains Unix timestamp of last reminder
+- 120-second (2-minute) cooldown period
+- Safe to delete if behavior needs to be reset
+
+Limitations:
+- Only detects GitHub Actions workflows (not Travis, CircleCI, etc.)
+- Workflow existence check is local (may not match remote configuration)
+- Only monitors Bash tool (not direct API operations from other tools)
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Cooldown period in seconds (2 minutes)
+COOLDOWN_PERIOD = 120
+
+# State file location
+STATE_DIR = Path.home() / ".claude" / "hook-state"
+STATE_FILE = STATE_DIR / "monitor-ci-cooldown"
+
+# Patterns to detect push and PR creation
+GIT_PUSH_PATTERN = r'git\s+push'
+GH_PR_CREATE_PATTERN = r'gh\s+pr\s+create'
+GITHUB_API_PR_CREATE_PATTERN = r'curl.*POST.*github\.com/repos/[^/]+/[^/]+/pulls'
+
+
+def is_git_push(command: str) -> bool:
+    """Check if command is a git push."""
+    try:
+        return bool(re.search(GIT_PUSH_PATTERN, command, re.IGNORECASE))
+    except Exception:
+        return False
+
+
+def is_pr_creation(command: str) -> bool:
+    """Check if command creates a PR (via gh CLI or GitHub API)."""
+    try:
+        # Check for gh pr create
+        if re.search(GH_PR_CREATE_PATTERN, command, re.IGNORECASE):
+            return True
+        # Check for GitHub API PR creation
+        if re.search(GITHUB_API_PR_CREATE_PATTERN, command, re.IGNORECASE):
+            return True
+        return False
+    except Exception:
+        return False
+
+
+def has_github_workflows() -> bool:
+    """Check if the repository has GitHub Actions workflows."""
+    try:
+        # Check common locations for workflow files
+        workflows_dir = Path(".github/workflows")
+        if workflows_dir.exists() and workflows_dir.is_dir():
+            # Check if there are any YAML files
+            yaml_files = list(workflows_dir.glob("*.yml")) + list(workflows_dir.glob("*.yaml"))
+            return len(yaml_files) > 0
+        return False
+    except Exception:
+        return False
+
+
+def is_gh_available() -> bool:
+    """Check if gh CLI is available."""
+    try:
+        return shutil.which("gh") is not None
+    except Exception:
+        return False
+
+
+def has_github_token() -> bool:
+    """Check if GITHUB_TOKEN environment variable is set."""
+    return bool(os.environ.get("GITHUB_TOKEN"))
+
+
+def is_within_cooldown() -> bool:
+    """Check if we're within the cooldown period since last reminder."""
+    try:
+        if not STATE_FILE.exists():
+            return False
+
+        last_reminder_time = float(STATE_FILE.read_text().strip())
+        current_time = time.time()
+
+        return (current_time - last_reminder_time) < COOLDOWN_PERIOD
+    except Exception:
+        # Gracefully handle corrupted state file
+        return False
+
+
+def record_reminder():
+    """Record that we just provided a reminder."""
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        STATE_FILE.write_text(str(time.time()))
+    except Exception as e:
+        # Log but don't fail - cooldown is nice-to-have, not critical
+        print(f"Warning: Could not record cooldown state: {e}", file=sys.stderr)
+
+
+def format_cooldown_message() -> str:
+    """Format the cooldown period message based on COOLDOWN_PERIOD constant."""
+    if COOLDOWN_PERIOD < 60:
+        return f"*This reminder appears every {COOLDOWN_PERIOD} seconds.*"
+    elif COOLDOWN_PERIOD == 60:
+        return "*This reminder appears once per minute.*"
+    elif COOLDOWN_PERIOD % 60 == 0:
+        minutes = COOLDOWN_PERIOD // 60
+        if minutes == 1:
+            return "*This reminder appears once per minute.*"
+        else:
+            return f"*This reminder appears every {minutes} minutes.*"
+    else:
+        return f"*This reminder appears every {COOLDOWN_PERIOD} seconds.*"
+
+
+def get_guidance_for_push() -> str:
+    """Generate CI monitoring guidance for git push."""
+    gh_available = is_gh_available()
+    has_token = has_github_token()
+
+    guidance = """**CI MONITORING REMINDER**
+
+You just pushed commits. Consider monitoring CI results to catch issues early.
+
+"""
+
+    if gh_available:
+        guidance += """**Check CI status with gh CLI:**
+```bash
+# List recent workflow runs
+gh run list --limit 5
+
+# Watch a specific run (will wait for completion)
+gh run watch
+
+# View details of the latest run
+gh run view
+```
+
+"""
+    elif has_token:
+        guidance += """**Check CI status via GitHub API:**
+```bash
+# List recent workflow runs
+curl -s -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
+  -H "Accept: application/vnd.github.v3+json" \\
+  "https://api.github.com/repos/OWNER/REPO/actions/runs?per_page=5"
+
+# Get status of a specific run
+curl -s -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
+  -H "Accept: application/vnd.github.v3+json" \\
+  "https://api.github.com/repos/OWNER/REPO/actions/runs/RUN_ID"
+```
+
+"""
+    else:
+        guidance += """**Check CI status:**
+Visit the repository's Actions tab on GitHub to monitor workflow runs.
+
+"""
+
+    guidance += """**Why monitor CI:**
+- Catch failures while context is fresh
+- Prevent broken main branch
+- Address issues before they compound
+
+"""
+    guidance += format_cooldown_message()
+    return guidance
+
+
+def get_guidance_for_pr() -> str:
+    """Generate CI monitoring guidance for PR creation."""
+    gh_available = is_gh_available()
+    has_token = has_github_token()
+
+    guidance = """**CI MONITORING REMINDER**
+
+You just created a PR. Consider monitoring CI checks to ensure they pass.
+
+"""
+
+    if gh_available:
+        guidance += """**Check PR status with gh CLI:**
+```bash
+# View PR checks status
+gh pr checks
+
+# Watch PR checks (will wait for completion)
+gh pr checks --watch
+
+# View PR details including check status
+gh pr view
+```
+
+"""
+    elif has_token:
+        guidance += """**Check PR status via GitHub API:**
+```bash
+# Get PR check runs
+curl -s -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
+  -H "Accept: application/vnd.github.v3+json" \\
+  "https://api.github.com/repos/OWNER/REPO/pulls/PR_NUMBER/commits" | \\
+  jq -r '.[0].sha' | xargs -I {} curl -s \\
+  -H "Authorization: token $(printenv GITHUB_TOKEN)" \\
+  -H "Accept: application/vnd.github.v3+json" \\
+  "https://api.github.com/repos/OWNER/REPO/commits/{}/check-runs"
+```
+
+"""
+    else:
+        guidance += """**Check PR status:**
+Visit the PR page on GitHub to monitor check status in the "Checks" tab.
+
+"""
+
+    guidance += """**Why monitor PR checks:**
+- Address failures before requesting review
+- Ensure code meets quality gates
+- Faster iteration on issues
+
+"""
+    guidance += format_cooldown_message()
+    return guidance
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+        tool_name = input_data.get("tool_name", "")
+        tool_input = input_data.get("tool_input", {})
+
+        # Only monitor Bash tool
+        if tool_name != "Bash":
+            print("{}")
+            sys.exit(0)
+
+        # Extract command from tool input
+        command = tool_input.get("command", "")
+
+        # Check for errors - don't remind if the command failed
+        # PostToolUse may have errors in tool_result
+        tool_result = input_data.get("tool_result", {})
+        if tool_result.get("error"):
+            print("{}")
+            sys.exit(0)
+
+        # Check if this is a git push
+        if is_git_push(command):
+            # Check if repo has CI workflows
+            if not has_github_workflows():
+                print("{}")
+                sys.exit(0)
+
+            # Check cooldown
+            if is_within_cooldown():
+                print("{}")
+                sys.exit(0)
+
+            # Record this reminder
+            record_reminder()
+
+            # Provide CI monitoring guidance
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": get_guidance_for_push()
+                }
+            }
+
+            print(json.dumps(output))
+            sys.exit(0)
+
+        # Check if this is a PR creation
+        if is_pr_creation(command):
+            # Check if repo has CI workflows
+            if not has_github_workflows():
+                print("{}")
+                sys.exit(0)
+
+            # Check cooldown
+            if is_within_cooldown():
+                print("{}")
+                sys.exit(0)
+
+            # Record this reminder
+            record_reminder()
+
+            # Provide CI monitoring guidance
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": get_guidance_for_pr()
+                }
+            }
+
+            print(json.dumps(output))
+            sys.exit(0)
+
+        # Not a triggering command
+        print("{}")
+        sys.exit(0)
+
+    except Exception as e:
+        # Log to stderr for debugging
+        print(f"Error in monitor-ci-results hook: {e}", file=sys.stderr)
+        # Always output valid JSON on error
+        print("{}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `monitor-ci-results.py` hook that reminds Claude to monitor CI results after pushing commits or creating PRs
- Only triggers when repo has GitHub Actions workflows (`.github/workflows/`)
- Provides guidance for checking CI status via `gh run` commands or GitHub API
- Includes 2-minute cooldown to avoid repetitive reminders

## Implementation Details

**Triggers on:**
- `git push` (any successful push to remote)
- `gh pr create` (PR creation via gh CLI)
- `curl -X POST .../pulls` (PR creation via GitHub API)

**Smart detection:**
- Checks for `.github/workflows/*.yml` or `.github/workflows/*.yaml` files
- Detects if `gh` CLI is available and provides appropriate guidance
- Falls back to GitHub API curl commands if `gh` is unavailable

**Files added/changed:**
- `plugins/claude-code-hooks/hooks/monitor-ci-results.py` - Main hook implementation
- `.claude/hooks/monitor-ci-results.py` - Symlink for Web compatibility
- `.claude/hooks/tests/test_monitor_ci_results.py` - 37 comprehensive tests
- `.claude/settings.json` - Hook configuration added to PostToolUse

## Test plan

- [x] All 37 new tests pass
- [x] Full test suite (518 tests) passes
- [x] Manual testing confirms hook triggers correctly
- [ ] Verify hook works in actual git push/PR creation workflow

Closes #40