### PR TITLE
feat: add GitHub Actions workflow template for syncing config to other repos

### DIFF
--- a/.github/workflow-templates/sync-claude-config.yml
+++ b/.github/workflow-templates/sync-claude-config.yml
@@ -39,6 +39,8 @@ jobs:
           repository: ${{ env.SOURCE_REPO }}
           ref: ${{ env.SOURCE_BRANCH }}
           path: _source_config
+          # For private source repos, add SOURCE_REPO_TOKEN secret with read access
+          token: ${{ secrets.SOURCE_REPO_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Get source commit info
         id: source-info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,9 @@ For Claude Code Web usage in other repositories, you can use the provided GitHub
 
 **Setup (per repository):**
 1. Copy `.github/workflow-templates/sync-claude-config.yml` to your target repo's `.github/workflows/`
-2. The workflow runs weekly and creates PRs when updates are available
-3. Manually trigger via Actions tab for immediate sync
+2. If source repo is private: add a `SOURCE_REPO_TOKEN` secret with read access
+3. The workflow runs weekly and creates PRs when updates are available
+4. Manually trigger via Actions tab for immediate sync
 
 **What gets synced:**
 - `.claude/settings.json` - Permissions and hooks configuration


### PR DESCRIPTION
## Summary

- Adds a pull-based GitHub Actions workflow template for syncing Claude Code config to other repositories
- Documents usage in CLAUDE.md

This addresses #49 by providing a practical workaround for using this configuration in other GitHub projects via Claude Code Web.

## How It Works

Other repositories copy the workflow template to `.github/workflows/`. The workflow:
- Runs weekly and creates PRs when updates are available
- Resolves symlinks (hooks → actual files)
- Preserves local customizations (`settings.local.json`, `.local-config`)
- Supports manual triggering for immediate sync

## Test Plan

- [ ] Copy workflow to a test repository
- [ ] Trigger manually via Actions tab
- [ ] Verify PR is created with resolved hook files
- [ ] Verify local customizations are preserved

https://claude.ai/code/session_015wVmR5Sdfodfx4fYekyHLf