### PR TITLE
fix(plugins): register ralph-loop-guide in marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -47,6 +47,27 @@
       "skills": [
         "./skills/alfred-workflow"
       ]
+    },
+    {
+      "name": "ralph-loop-guide",
+      "description": "Best practices reference for writing effective ralph-loop prompts. Use when helping users structure prompts for autonomous coding loops, configure completion criteria, design quality gates, or debug convergence issues.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jython1415",
+        "url": "https://github.com/Jython1415"
+      },
+      "source": "./plugins/ralph-loop-guide",
+      "category": "development",
+      "keywords": [
+        "ralph-loop",
+        "autonomous",
+        "coding-loop",
+        "prompts",
+        "best-practices"
+      ],
+      "skills": [
+        "./skills/ralph-loop-guide"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- The `ralph-loop-guide` plugin was merged in PR #65 but was never added to `.claude-plugin/marketplace.json`, so the marketplace couldn't discover or install it
- Adds the plugin entry with source path, skills reference, and metadata matching the existing plugin format

## Test plan
- [ ] Verify `claude plugin list` shows `ralph-loop-guide` from the `claude-code-config` marketplace
- [ ] Enable with `ralph-loop-guide@claude-code-config` in settings and confirm the skill loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)