### PR TITLE
docs(claude): add branch-first workflow rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,9 @@ When working in this repository, you are managing the user's Claude Code configu
 - Test permission changes carefully
 - Document why permissions were added/changed in commit messages
 
+### Workflow
+Always create a feature branch before committing changes. Never commit directly to `main`. Use the `/solve` pattern (or create a branch manually) before making the first commit.
+
 ### Commit Messages
 Follow conventional commit format:
 ```


### PR DESCRIPTION
Adds a Workflow section to CLAUDE.md capturing the branch-first rule: always create a feature branch before committing, never commit directly to `main`.

Sourced from /reflect after a session where a commit landed on main and required branch surgery to isolate into a PR.