### PR TITLE
ci(plugins): add version-check workflow

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,77 @@
+name: Version Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'plugins/**'
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check plugin versions
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+
+          # Get all changed files under plugins/
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- 'plugins/')
+
+          # Extract unique candidate directory names (second path component)
+          PLUGINS=$(echo "$CHANGED" | grep '^plugins/' | cut -d'/' -f2 | sort -u)
+
+          if [ -z "$PLUGINS" ]; then
+            echo "No plugin directories changed."
+            exit 0
+          fi
+
+          ERRORS=0
+
+          for PLUGIN in $PLUGINS; do
+            MANIFEST="plugins/$PLUGIN/.claude-plugin/plugin.json"
+
+            # Skip if not a plugin directory (e.g., installed_plugins.json)
+            if [ ! -f "$MANIFEST" ]; then
+              echo "Skipping '$PLUGIN' (no plugin.json found)"
+              continue
+            fi
+
+            PLUGIN_CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- "plugins/$PLUGIN/")
+
+            # If only plugin.json changed, no further checks needed
+            NON_MANIFEST=$(echo "$PLUGIN_CHANGED" | grep -v "^plugins/$PLUGIN/\.claude-plugin/plugin\.json$" || true)
+            if [ -z "$NON_MANIFEST" ]; then
+              echo "✓ $PLUGIN: Only plugin.json changed"
+              continue
+            fi
+
+            # Non-plugin.json files changed — version must be bumped
+            OLD_VERSION=$(git show "$BASE:$MANIFEST" 2>/dev/null | jq -r '.version // empty')
+            NEW_VERSION=$(jq -r '.version // empty' "$MANIFEST")
+
+            if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
+              echo "✗ $PLUGIN: Files changed but version was not bumped (still $NEW_VERSION)."
+              echo "  Update the \"version\" field in $MANIFEST"
+              ERRORS=$((ERRORS + 1))
+              continue
+            fi
+
+            # Version was bumped — check for duplicate tag
+            TAG="$PLUGIN-v$NEW_VERSION"
+            if git tag -l "$TAG" | grep -q "^$TAG$"; then
+              echo "✗ $PLUGIN: Version $NEW_VERSION already released (tag $TAG exists). Bump to a new version."
+              ERRORS=$((ERRORS + 1))
+            else
+              echo "✓ $PLUGIN: Version bumped $OLD_VERSION → $NEW_VERSION"
+            fi
+          done
+
+          if [ "$ERRORS" -gt 0 ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/version-check.yml` that fails PRs modifying plugin files without bumping the `version` field in `plugin.json`
- Mirrors the version enforcement pattern from [claude-ai-skills](https://github.com/Jython1415/claude-ai-skills)
- Skips non-plugin paths (e.g., `installed_plugins.json`) and passes cleanly when only `plugin.json` itself changes

## How it works
1. Diffs PR base→head to find changed files under `plugins/`
2. Extracts affected plugin directories (those with a `.claude-plugin/plugin.json`)
3. For each plugin with non-`plugin.json` changes: requires the `version` field to have changed
4. Also blocks reuse of an already-tagged version

## Test plan
- [ ] Open a PR that changes a hook file without bumping `plugin.json` → check fails
- [ ] Open a PR that changes a hook file and bumps `plugin.json` version → check passes
- [ ] Open a PR that only changes `installed_plugins.json` → check skips cleanly

Closes #87

---
*Created with assistance from Claude Code*
