### PR TITLE
ci(version-check): verify marketplace.json versions match plugin.json

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -42,33 +42,49 @@ jobs:
               continue
             fi
 
-            PLUGIN_CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- "plugins/$PLUGIN/")
-
-            # If only plugin.json changed, no further checks needed
-            NON_MANIFEST=$(echo "$PLUGIN_CHANGED" | grep -v "^plugins/$PLUGIN/\.claude-plugin/plugin\.json$" || true)
-            if [ -z "$NON_MANIFEST" ]; then
-              echo "✓ $PLUGIN: Only plugin.json changed"
-              continue
-            fi
-
-            # Non-plugin.json files changed — version must be bumped
             OLD_VERSION=$(git show "$BASE:$MANIFEST" 2>/dev/null | jq -r '.version // empty')
             NEW_VERSION=$(jq -r '.version // empty' "$MANIFEST")
 
-            if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
-              echo "✗ $PLUGIN: Files changed but version was not bumped (still $NEW_VERSION)."
-              echo "  Update the \"version\" field in $MANIFEST"
-              ERRORS=$((ERRORS + 1))
-              continue
+            PLUGIN_CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- "plugins/$PLUGIN/")
+
+            # If only plugin.json changed, no version bump enforcement needed
+            NON_MANIFEST=$(echo "$PLUGIN_CHANGED" | grep -v "^plugins/$PLUGIN/\.claude-plugin/plugin\.json$" || true)
+            if [ -z "$NON_MANIFEST" ]; then
+              echo "✓ $PLUGIN: Only plugin.json changed"
+            else
+              # Non-plugin.json files changed — version must be bumped
+              if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
+                echo "✗ $PLUGIN: Files changed but version was not bumped (still $NEW_VERSION)."
+                echo "  Update the \"version\" field in $MANIFEST"
+                ERRORS=$((ERRORS + 1))
+                continue
+              fi
+
+              # Version was bumped — check for duplicate tag
+              TAG="$PLUGIN-v$NEW_VERSION"
+              if git tag -l "$TAG" | grep -q "^$TAG$"; then
+                echo "✗ $PLUGIN: Version $NEW_VERSION already released (tag $TAG exists). Bump to a new version."
+                ERRORS=$((ERRORS + 1))
+                continue
+              fi
+
+              echo "✓ $PLUGIN: Version bumped $OLD_VERSION → $NEW_VERSION"
             fi
 
-            # Version was bumped — check for duplicate tag
-            TAG="$PLUGIN-v$NEW_VERSION"
-            if git tag -l "$TAG" | grep -q "^$TAG$"; then
-              echo "✗ $PLUGIN: Version $NEW_VERSION already released (tag $TAG exists). Bump to a new version."
-              ERRORS=$((ERRORS + 1))
-            else
-              echo "✓ $PLUGIN: Version bumped $OLD_VERSION → $NEW_VERSION"
+            # When the version changed, verify marketplace.json is in sync
+            if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+              MARKETPLACE=".claude-plugin/marketplace.json"
+              PLUGIN_NAME=$(jq -r '.name // empty' "$MANIFEST")
+              MARKET_VERSION=$(jq -r --arg name "$PLUGIN_NAME" '.plugins[] | select(.name == $name) | .version // empty' "$MARKETPLACE")
+              if [ -z "$MARKET_VERSION" ]; then
+                echo "  Note: $PLUGIN_NAME not found in $MARKETPLACE (skipping marketplace sync check)"
+              elif [ "$MARKET_VERSION" != "$NEW_VERSION" ]; then
+                echo "✗ $PLUGIN: marketplace.json version ($MARKET_VERSION) does not match plugin.json version ($NEW_VERSION)."
+                echo "  Update the \"version\" field in $MARKETPLACE for the \"$PLUGIN_NAME\" entry"
+                ERRORS=$((ERRORS + 1))
+              else
+                echo "  ✓ marketplace.json in sync ($NEW_VERSION)"
+              fi
             fi
           done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,7 @@ Each plugin has a `version` field in `plugins/<name>/.claude-plugin/plugin.json`
 - **Minor** (1.x.0): New hooks or skills added
 - **Major** (x.0.0): Breaking changes (removed hooks, renamed skills, changed interfaces)
 
-**Rule**: Bump the version in the same commit that ships the change. Never let `plugin.json` lag behind. CI enforces this on every PR that touches plugin files.
-
-Also keep `.claude-plugin/marketplace.json` in sync — it duplicates per-plugin version fields and is not currently checked by CI.
+**Rule**: Bump the version in the same commit that ships the change. Never let `plugin.json` lag behind. CI enforces this on every PR that touches plugin files. Also keep `.claude-plugin/marketplace.json` in sync — CI verifies that its per-plugin version fields match `plugin.json` whenever a version is bumped.
 
 ### Writing Skills
 - Do not use `allowed-tools` in skill frontmatter


### PR DESCRIPTION
## Summary

- Extends `version-check.yml` to verify that `.claude-plugin/marketplace.json` per-plugin versions match `plugins/<name>/.claude-plugin/plugin.json` whenever a version is bumped
- Fires in both the "non-manifest files changed + version bumped" path and the "only plugin.json changed" path
- Updates CLAUDE.md to reflect that this is now enforced by CI (removes the manual note)

## Test plan

- [ ] Open a PR that bumps a plugin version in `plugin.json` but not in `marketplace.json` → CI should fail with a clear error message
- [ ] Open a PR that bumps both in sync → CI should pass with `✓ marketplace.json in sync`
- [ ] Open a PR that changes plugin files but not the version → existing "version not bumped" error still fires (marketplace check is skipped since no version change)

Closes #93
