### PR TITLE
feat(skills): add trigger phrases to skill descriptions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,7 +72,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/skills/issue/SKILL.md
+++ b/plugins/dev-workflow/skills/issue/SKILL.md
@@ -2,9 +2,11 @@
 name: issue
 description: |
   File a well-researched GitHub issue from a brief description.
-  Explores the codebase, checks for duplicates, and drafts a
-  structured issue. Asks the user to clarify only when the
-  description is genuinely ambiguous.
+  Use when asked to file an issue, create an issue, open an issue,
+  or report a bug or feature request in a GitHub repo. Explores
+  the codebase, checks for duplicates, and drafts a structured
+  issue. Asks the user to clarify only when the description is
+  genuinely ambiguous.
 argument-hint: <description>
 ---
 

--- a/plugins/dev-workflow/skills/reflect/SKILL.md
+++ b/plugins/dev-workflow/skills/reflect/SKILL.md
@@ -3,7 +3,9 @@ name: reflect
 description: >
   End-of-session retrospective. Reviews what happened, extracts lessons,
   and proposes concrete improvements to docs, skills, and memory to
-  make future sessions better. Run before context is lost.
+  make future sessions better. Use at the end of a session, after a
+  notable misstep or discovery, or when the user asks to wrap up or
+  reflect. Run before context is lost.
 ---
 
 # Reflect

--- a/plugins/dev-workflow/skills/session/SKILL.md
+++ b/plugins/dev-workflow/skills/session/SKILL.md
@@ -3,7 +3,8 @@ name: session
 description: >
   Full dev session lifecycle: triage open issues, solve the top
   priority item, then reflect on lessons learned. Chains /triage,
-  /solve, and /reflect into a single workflow.
+  /solve, and /reflect into a single workflow. Use at the start of
+  a working session to run the full dev lifecycle end-to-end.
 ---
 
 # Session

--- a/plugins/dev-workflow/skills/solve/SKILL.md
+++ b/plugins/dev-workflow/skills/solve/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: solve
 description: >
-  Turn GitHub issues into reviewed pull requests. Explores the codebase,
-  collaboratively scopes design decisions with the user, plans the
-  implementation, builds it, and runs code review before presenting the PR.
+  Turn GitHub issues into reviewed pull requests. Use when asked to
+  implement an issue, fix a bug from a GitHub issue, or build a
+  feature tracked in an issue. Explores the codebase, collaboratively
+  scopes design decisions with the user, plans the implementation,
+  builds it, and runs code review before presenting the PR.
 argument-hint: <issue> [<issue> ...]
 ---
 


### PR DESCRIPTION
## Summary
- Adds explicit 'Use when...' trigger phrases to the frontmatter descriptions of issue, solve, session, and reflect skills
- Follows the code-review pattern, which already had reliable trigger coverage
- triage and consult already had adequate trigger phrases and were not changed

## Motivation
Claude Code uses skill frontmatter descriptions as the primary signal for matching user intent to skills. Without explicit trigger phrases, skills like `issue` and `solve` are not reliably invoked when users say natural phrases like 'file an issue' or 'implement this issue'.

Closes #94