### PR TITLE
feat(code-review): expand convention doc discovery to CONTRIBUTING, ARCHITECTURE, DEVELOPMENT

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,7 +72,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/skills/code-review/SKILL.md
+++ b/plugins/dev-workflow/skills/code-review/SKILL.md
@@ -22,10 +22,11 @@ Follow these steps precisely:
 ## Step 1: Gather context (2 parallel agents)
 
 **Agent A (haiku):** Return a list of file paths for all relevant convention
-documents (CLAUDE.md and README.md files):
-- The root CLAUDE.md and README.md, if they exist
-- Any CLAUDE.md or README.md files in directories containing modified
-  files, and all parent directories up to the repo root
+documents (CLAUDE.md, README.md, CONTRIBUTING.md, ARCHITECTURE.md,
+DEVELOPMENT.md, and similar files that codify codebase practices):
+- Convention documents in the repo root, if they exist
+- Any convention documents in directories containing modified files, and
+  all parent directories up to the repo root
 
 Use `gh pr diff` and Glob to identify these.
 


### PR DESCRIPTION
## Summary
- Expands Agent A's convention document discovery beyond CLAUDE.md and README.md
- Now also finds CONTRIBUTING.md, ARCHITECTURE.md, DEVELOPMENT.md, and 'similar files that codify codebase practices'
- Gives Agent A discretion for other practice-codifying documents that may exist in different repos

## Motivation
Follow-up from #91 — CONTRIBUTING.md, ARCHITECTURE.md, and DEVELOPMENT.md are common convention documents that should be included in compliance checks alongside CLAUDE.md and README.md.