### PR TITLE
fix(hooks): use permissionDecision: deny in block-heredoc-in-bash

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "claude-code-hooks",
       "description": "Productivity hooks for Claude Code: line ending normalization, gh attribution reminders, modern tool suggestions, and more",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/.claude/hooks/tests/test_block_heredoc_in_bash.py
+++ b/.claude/hooks/tests/test_block_heredoc_in_bash.py
@@ -78,17 +78,17 @@ class TestHeredocBlocking:
         output = run_hook("Write", "cat <<EOF\nsome content\nEOF")
         assert output == {}
 
-    def test_block_output_has_decision_field(self):
-        """Blocked commands should have decision: block in hook output"""
+    def test_block_output_has_permission_decision_field(self):
+        """Blocked commands should have permissionDecision: deny in hook output"""
         output = run_hook("Bash", "cat <<EOF\nfoo\nEOF")
-        assert output["hookSpecificOutput"]["decision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-    def test_block_output_has_additional_context(self):
-        """Blocked commands should have non-empty additionalContext"""
+    def test_block_output_has_permission_decision_reason(self):
+        """Blocked commands should have non-empty permissionDecisionReason"""
         output = run_hook("Bash", "cat <<EOF\nfoo\nEOF")
         hook_output = output["hookSpecificOutput"]
-        assert "additionalContext" in hook_output
-        assert len(hook_output["additionalContext"]) > 0
+        assert "permissionDecisionReason" in hook_output
+        assert len(hook_output["permissionDecisionReason"]) > 0
 
     def test_block_output_has_hook_event_name(self):
         """Blocked output should include hookEventName"""
@@ -115,7 +115,7 @@ class TestHeredocBlocking:
         """Heredoc with a non-EOF delimiter should also be blocked"""
         output = run_hook("Bash", "cat <<BODY\nsome content\nBODY")
         assert "hookSpecificOutput" in output
-        assert output["hookSpecificOutput"]["decision"] == "block"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_no_block_for_arithmetic_left_shift(self):
         """Arithmetic left shift should not trigger the heredoc blocker"""

--- a/plugins/claude-code-hooks/.claude-plugin/plugin.json
+++ b/plugins/claude-code-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-hooks",
   "description": "Productivity hooks for Claude Code: line ending normalization, gh attribution reminders, modern tool suggestions, and more",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/claude-code-hooks/hooks/block-heredoc-in-bash.py
+++ b/plugins/claude-code-hooks/hooks/block-heredoc-in-bash.py
@@ -48,8 +48,8 @@ def main():
     output = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "decision": "block",
-            "additionalContext": (
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
                 "**BLOCKED: Heredoc syntax detected**\n\n"
                 "Heredoc (`<<EOF`) silently fails in sandbox mode — the shell cannot "
                 "create the required temp file, which corrupts the command without any "


### PR DESCRIPTION
Fix `block-heredoc-in-bash` hook to actually block heredoc commands by replacing the invalid `decision: "block"` field with the correct `permissionDecision: "deny"` field documented by Claude Code.

## Problem

The hook output used `hookSpecificOutput.decision: "block"`, which is not a valid Claude Code hook field. It is neither:
- The old deprecated **top-level** `decision` field, nor
- The new `hookSpecificOutput.permissionDecision` field

As a result, the hook provided guidance text via `additionalContext` but **never actually blocked** heredoc commands from executing.

## Fix

- `decision: "block"` → `permissionDecision: "deny"`
- `additionalContext` → `permissionDecisionReason` (the field shown to Claude on deny)
- Updated tests to check for the correct field names
- Bumps version `1.5.1` → `1.5.2`

## References

From the official Claude Code hooks docs:
> *"PreToolUse previously used top-level `decision` and `reason` fields, but these are deprecated for this event. Use `hookSpecificOutput.permissionDecision` and `hookSpecificOutput.permissionDecisionReason` instead."*

Closes #110

---
*Created with assistance from Claude Code*
