### PR TITLE
fix(tests): redirect hook state to fix sandbox failures

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "claude-code-hooks",
       "description": "Productivity hooks for Claude Code: line ending normalization, gh attribution reminders, modern tool suggestions, and more",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/claude-code-hooks/.claude-plugin/plugin.json
+++ b/plugins/claude-code-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-hooks",
   "description": "Productivity hooks for Claude Code: line ending normalization, gh attribution reminders, modern tool suggestions, and more",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/claude-code-hooks/hooks/prefer-gh-for-own-repos.py
+++ b/plugins/claude-code-hooks/hooks/prefer-gh-for-own-repos.py
@@ -64,7 +64,8 @@ TARGET_OWNER = "Jython1415"
 COOLDOWN_PERIOD = 60
 
 # State file location
-STATE_DIR = Path.home() / ".claude" / "hook-state"
+_state_dir_env = os.environ.get("CLAUDE_HOOK_STATE_DIR")
+STATE_DIR = Path(_state_dir_env) if _state_dir_env else Path.home() / ".claude" / "hook-state"
 
 
 def is_gh_available():


### PR DESCRIPTION
Fix sandbox-blocked state file operations that cause 67 test failures.

## Root causes
- `test_prefer_gh_for_own_repos.py` (42 failures): test helper calls `unlink()` on `~/.claude/hook-state/` — blocked by sandbox, crashes all tests before any assertion runs
- `test_gh_authorship_attribution.py` (25 failures): `record_first_trigger()` had no error handling; sandbox-blocked write bubbled up to `main()` error handler, returning `{}` instead of guidance

## Changes
- Both hooks: add `CLAUDE_HOOK_STATE_DIR` env var support (production unchanged; tests redirect to `$TMPDIR/claude-hook-test-state`)
- `gh-authorship-attribution.py`: wrap `record_first_trigger()` in `try/except` matching `record_suggestion()` pattern
- Both test files: point state operations to writable temp dir via env var

Closes #113
