### PR TITLE
feat(dev-workflow): add --light mode to code-review, solve, and session

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,7 +72,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "1.0.11",
+      "version": "1.1.0",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/skills/code-review/SKILL.md
+++ b/plugins/dev-workflow/skills/code-review/SKILL.md
@@ -5,6 +5,7 @@ description: >
   after creating or updating a pull request, when asked to check code
   quality before merging, or when doing a final review of changes.
   Checks for bugs, logic errors, and convention document compliance.
+argument-hint: "[--light] [--comment]"
 ---
 
 # Code Review
@@ -17,7 +18,38 @@ parallel agents.
 - All tools are functional. Do not test tools or make exploratory calls.
 - Only call a tool if required. Every tool call should have a clear purpose.
 
-Follow these steps precisely:
+## Arguments
+
+- `--light`: Single-agent Sonnet review instead of the full multi-agent
+  pipeline. Appropriate for docs, version bumps, and small isolated changes.
+  Replaces Steps 1–3 with one structured pass; Steps 4–5 apply normally.
+- `--comment`: Post inline GitHub comments for each finding (applies in
+  both modes).
+
+## Light Mode (when --light is passed)
+
+Skip Steps 1–3. Launch **one Sonnet agent** with the PR number and these
+instructions:
+
+1. Run `gh pr view <PR_NUMBER>` to get the PR title and description.
+2. Run `gh pr diff <PR_NUMBER>` to get the full diff.
+3. Review the diff for real issues only. For each finding, it must have:
+   - **Category**: one of `correctness`, `security`, `convention`,
+     `performance`
+   - **Severity**: one of `critical`, `major`, `minor`
+   - **Evidence**: the exact code snippet from the diff that demonstrates
+     the issue — if you cannot cite a specific snippet, skip the finding
+   - **Confidence**: 0.0–1.0 — skip any finding below 0.7
+
+Apply the same HIGH SIGNAL ONLY standard as the full review: flag only
+issues where code will definitely fail, produce wrong results regardless
+of inputs, or clearly violate a stated convention. Return a list of
+findings with: file path, line range, category, severity, description,
+evidence, confidence.
+
+After this agent returns, proceed to Step 4.
+
+Follow these steps precisely (full mode only — skip if --light was passed):
 
 ## Step 1: Gather context (2 parallel agents)
 

--- a/plugins/dev-workflow/skills/session/SKILL.md
+++ b/plugins/dev-workflow/skills/session/SKILL.md
@@ -5,12 +5,20 @@ description: >
   priority item, then reflect on lessons learned. Chains /triage,
   /solve, and /reflect into a single workflow. Use at the start of
   a working session to run the full dev lifecycle end-to-end.
+argument-hint: "[--light]"
 ---
 
 # Session
 
 Run a complete dev session from start to finish. This skill chains
 three phases, each backed by a dedicated skill.
+
+## Arguments
+
+- `--light`: Run the session in cost-efficient mode. Propagates to
+  `/solve`, which passes it to `/code-review`. Code review uses a single
+  Sonnet agent instead of the full multi-agent Opus pipeline. Use for
+  routine sessions where the PRs are likely to be small or low-risk.
 
 ## Phase 1: Triage
 
@@ -43,6 +51,8 @@ solve cycle (intake → implement → review → merge) consumes most of the
 available context, so one item per session is the normal case. If the
 user explicitly asks to continue with more items, repeat Phase 2 for
 the next queue item after merging the current PR.
+
+If `--light` was passed to `/session`, invoke `/solve --light <issue>`.
 
 `/solve` runs the full issue-to-PR workflow:
 

--- a/plugins/dev-workflow/skills/solve/SKILL.md
+++ b/plugins/dev-workflow/skills/solve/SKILL.md
@@ -6,7 +6,7 @@ description: >
   feature tracked in an issue. Explores the codebase, collaboratively
   scopes design decisions with the user, plans the implementation,
   builds it, and runs code review before presenting the PR.
-argument-hint: <issue> [<issue> ...]
+argument-hint: "<issue> [<issue> ...] [--light]"
 ---
 
 # Solve
@@ -16,9 +16,13 @@ these phases in order. Do not skip phases unless explicitly noted.
 
 ## Arguments
 
-`$ARGUMENTS` contains issue references separated by spaces. Each may be a
-number (`42`), prefixed (`#42`), or a full URL. Parse all references and
-normalize to issue numbers.
+`$ARGUMENTS` contains issue references and optional flags separated by
+spaces. Parse:
+- Issue references: numbers (`42`), prefixed (`#42`), or full URLs —
+  normalize to issue numbers
+- `--light`: If present, use light code review in Phase 7 (single Sonnet
+  agent instead of the full multi-agent pipeline). Pass as `--light` when
+  invoking `/code-review`.
 
 ## Phase 1: Intake
 
@@ -137,13 +141,14 @@ correct config in the wrong format is a silent failure.
 
 Before presenting the PR to the user:
 
-1. Invoke `/code-review` using the Skill tool to run a thorough review of
-   the PR
+1. Invoke `/code-review` using the Skill tool to run a review of the PR:
+   - If `--light` was passed as an argument, invoke `/code-review --light`
+   - Otherwise, invoke `/code-review` for the full multi-agent review
 2. If the review surfaces real issues, fix them and commit -- do not
    pause to report intermediate findings to the user; act on them
    autonomously
-3. Re-run `/code-review` until clean -- the PR must pass review before
-   being presented to the user
+3. Re-run the same review mode until clean -- the PR must pass review
+   before being presented to the user
 
 ## Phase 8: Confirm CI
 


### PR DESCRIPTION
## Summary

- Adds `--light` flag to `/code-review`, `/solve`, and `/session` skills
- Light mode replaces the full 6+ agent Opus pipeline with a single Sonnet agent using structured output, evidence requirements, and confidence-threshold filtering
- Flag propagates through the chain: `/session --light` → `/solve --light` → `/code-review --light`
- Bumps dev-workflow plugin version 1.0.11 → 1.1.0

## Light mode design

Informed by research into CodeRabbit, Ellipsis, and Greptile architectures:

**Evidence requirement**: every finding must cite an exact code snippet from the diff. If no snippet can be cited, the finding is dropped. This acts as a built-in hallucination filter (Ellipsis's key innovation).

**Confidence threshold**: findings below 0.7 confidence are dropped automatically. This replaces the unbounded per-issue Opus validation agents that are the primary cost driver in full mode.

**Single structured agent**: one Sonnet agent handles both convention and bug detection with explicit output schema (category, severity, evidence, confidence) instead of 4 parallel agents with redundant coverage.

## When to use each mode

| Mode | Command | Best for |
|------|---------|----------|
| Full | `/code-review` | Logic-heavy PRs, multi-file changes, security-critical code |
| Light | `/code-review --light` | Docs, version bumps, small isolated fixes, routine sessions |

Closes #115

---
*Created with assistance from Claude Code*
