### PR TITLE
feat(code-review): research-informed improvements to --light prompt

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/skills/code-review/SKILL.md
+++ b/plugins/dev-workflow/skills/code-review/SKILL.md
@@ -34,13 +34,25 @@ instructions:
 
 1. Run `gh pr view <PR_NUMBER>` to get the PR title and description.
 2. Run `gh pr diff <PR_NUMBER>` to get the full diff.
-3. Do a thorough review. Work through these passes in order:
+3. **Fetch convention docs (mandatory):** Check for CLAUDE.md and README.md
+   in the repo root and in every directory that contains a modified file.
+   Read each file you find. Do this before any review passes begin.
+4. **Enumerate changed files:** List every file modified in the diff. Mark
+   any that are high-risk: authentication/authorization logic, state
+   mutation, external API calls, data serialization, security-adjacent code.
+   This list is your coverage checklist for Pass 3.
+5. **Orient:** Write 2–3 sentences summarizing what this PR does, in plain
+   language. This grounds the review passes that follow.
+6. Do a thorough review. Work through these passes in order:
 
-   **Pass 1 — Category sweep (before synthesizing anything):**
-   For each category below, scan the entire diff and note candidates:
+   **Pass 1 — Category sweep:**
+   Using the convention docs from step 3, work through each file from
+   step 4, starting with high-risk files. For each file, scan for
+   candidates in each category:
    - `correctness`: logic errors, wrong results, missing edge cases
    - `security`: injection, auth bypass, data exposure, unsafe operations
-   - `convention`: CLAUDE.md and README.md violations (read them if present)
+   - `convention`: violations of CLAUDE.md and README.md rules found in
+     step 3
    - `performance`: algorithmic issues, unnecessary work in hot paths
 
    **Pass 2 — Validate candidates:**
@@ -55,12 +67,14 @@ instructions:
      the issue — if you cannot cite a specific snippet, skip the finding
    - **Confidence**: 0.0–1.0 — skip any finding below 0.7
 
-   **Pass 3 — Self-check:**
-   Before returning, ask: "Is there anything I missed?" Re-read the diff
-   summary and any high-risk areas (auth, data mutation, external calls).
-   Add any new findings that pass the bar above.
+   **Pass 3 — Coverage check, then self-check:**
+   List every file from step 4. Confirm you examined each one in Pass 1.
+   For any file not yet examined, scan it now using the Pass 1 categories.
+   Then ask: "Is there anything I missed?" Re-read any high-risk areas
+   (auth, data mutation, external calls). Add new findings that pass the
+   bar above.
 
-4. Return a list of findings with: file path, line range, category,
+7. Return a list of findings with: file path, line range, category,
    severity, description, evidence, confidence.
 
 After this agent returns, proceed to Step 4.


### PR DESCRIPTION
## Summary

- **Mandatory convention doc fetch**: Step 3 now requires reading CLAUDE.md and README.md from the repo root and every directory containing a modified file — upfront, before any review passes. Previously buried as "read them if present" inside Pass 1 where it was easily skipped.
- **File enumeration with risk-flagging**: Step 4 lists all changed files and marks high-risk ones (auth, state mutation, external calls, serialization). Pass 1 works through them in risk-ranked order.
- **Upfront orientation summary**: Step 5 writes a 2–3 sentence plain-language summary of what the PR does before the category sweep begins.
- **Coverage check in Pass 3**: Before the existing self-check, the agent explicitly lists all files from step 4 and confirms each was examined in Pass 1 — scanning any missed files before moving on.

## Research basis

Informed by the sources linked in the issue:
- **arxiv 2505.16339** (WirelessCar empirical study): context is the #1 quality driver; "lacking broader repository context leads to superficial feedback." Their best-performing mode injected full PR context upfront and generated an orientation summary before detailed review.
- **CoT prompting research**: explicit step-by-step enumeration prevents systematic omissions; models that list items before analyzing them are more reliably thorough than those scanning holistically.
- **arxiv 2404.18496**: validated the category-sweep approach but offered limited single-agent prompting insight.
- **LLM-as-Judge** (Monte Carlo): page did not render; existing 0.7 confidence threshold and evidence requirement already reflect known best practices.

## Test plan

- [ ] Verify CI passes (version-check.yml confirms plugin.json and marketplace.json are in sync at 1.2.1)
- [ ] Read through revised `--light` section for clarity and internal consistency

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)
