### PR TITLE
feat(hook-development): consolidate hook authoring docs into skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
     {
       "name": "claude-code-misc",
       "description": "Miscellaneous skills and documentation for Claude Code development: hook authoring guide and hook reference",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/claude-code-misc/.claude-plugin/plugin.json
+++ b/plugins/claude-code-misc/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-misc",
   "description": "Miscellaneous skills and documentation for Claude Code development: hook authoring guide and hook reference",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"


### PR DESCRIPTION
## Summary

- **SKILL.md additions**: Three gaps filled to make the skill self-contained:
  - Fixed PEP 723 guidance — `requires-python` for dependency-free hooks, `dependencies` only when importing third-party packages, never `dependencies = []`
  - Added Hook Lifecycle Placement section — SessionStart vs PreToolUse/PostToolUse decision table with rules
  - Added Performance section — no network requests, no heavy compute in hot path
  - Removed Root `CLAUDE.md` from See Also (it's no longer a source of truth for hook authoring)
- **CLAUDE.md shrink**: Three hook sections (Modifying Hooks, Hook Development Guidelines 1–9, Hook Performance Assumptions) collapsed into a 2-line pointer; Testing Philosophy (50-line verbatim duplicate) replaced with a one-liner
- **Version bump**: `claude-code-misc` `1.0.0 → 1.0.1`

Publishing was already handled by #121. This completes the consolidation.

## Test plan

- [ ] CI passes (version-check.yml confirms claude-code-misc plugin.json and marketplace.json are in sync at 1.0.1)
- [ ] SKILL.md is self-contained — a new hook author can write a correct, tested, marketplace-ready hook using only the skill
- [ ] Root CLAUDE.md hook sections point to the skill rather than duplicating it

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
