### PR TITLE
fix(dev-workflow): convention-aware branching in /reflect, conditional research in /issue

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -93,7 +93,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.2.4] - 2026-02-27
+
+### Changed
+- `reflect`: Step 4 now checks convention documents (CLAUDE.md, CONTRIBUTING.md,
+  README.md, DEVELOPMENT.md, etc.) for a branching policy before committing.
+  Creates a branch + PR when a "never commit to main" rule is found; falls back
+  to direct-to-main only when no such policy exists. Closes #131.
+- `issue`: Phase 2 research is now conditional. Duplicate check (`gh issue list -S`)
+  always runs. The full Explore subagent only fires when the current session lacks
+  sufficient context (unfamiliar area, vague description). Closes #132.
+
 ## [1.2.3] - 2026-02-26
 
 ### Changed

--- a/plugins/dev-workflow/skills/issue/SKILL.md
+++ b/plugins/dev-workflow/skills/issue/SKILL.md
@@ -29,14 +29,22 @@ all phases. Research can run in parallel. File all issues at the end.
 
 ### 2. Research
 
-Delegate to a Task subagent (`subagent_type=Explore`, model=sonnet):
+**Duplicate check (always):** Run `gh issue list -S "keyword"` to check for
+existing duplicates. If a duplicate exists, stop and tell the user — don't file.
+If closely related issues exist, note them for cross-referencing in the issue body.
+
+**Explore (conditional):** Ask: do I already have enough context to write an
+accurate, well-grounded issue? Sufficient context means the issue was just
+encountered in the current session — e.g., you debugged this exact problem,
+the relevant files were already read, or the user described it with specific
+code-level detail.
+
+If context is insufficient (unfamiliar area, vague description, need to
+understand current behavior or check for related prior decisions), delegate
+to a Task subagent (`subagent_type=Explore`, model=sonnet):
 - Explore the relevant code area to understand current behavior
-- Check for duplicate or closely related open issues (`gh issue list -S "keyword"`)
 - Identify related issues that should be cross-referenced
 - Note relevant architecture, conventions, or prior decisions
-
-If a duplicate exists, stop and tell the user — don't file.
-If closely related issues exist, note them for cross-referencing in the issue body.
 
 ### 3. Scope (conditional)
 

--- a/plugins/dev-workflow/skills/reflect/SKILL.md
+++ b/plugins/dev-workflow/skills/reflect/SKILL.md
@@ -128,9 +128,15 @@ Make the approved changes:
 1. Edit documentation files
 2. Update or create skill files
 3. Update memory files
-4. Commit directly to main and push -- docs, skills, and memory are guidance,
-   not runtime code. Keeping the commit path lightweight encourages
-   actually running /reflect rather than skipping it.
+4. **Check branching policy before committing.** Scan convention documents
+   in the repo root (CLAUDE.md, CONTRIBUTING.md, README.md, DEVELOPMENT.md,
+   and any similar docs) for a "never commit to main" or "always use a
+   feature branch" policy.
+   - **Policy found**: create a feature branch (e.g., `reflect/YYYYMMDD`),
+     commit, push, and open a PR.
+   - **No such policy**: commit directly to main and push -- docs, skills,
+     and memory are guidance, not runtime code. Keeping the commit path
+     lightweight encourages actually running /reflect rather than skipping it.
 
 ## Principles
 


### PR DESCRIPTION
## Summary

- **`/reflect` Step 4** now scans convention documents (CLAUDE.md, CONTRIBUTING.md, README.md, DEVELOPMENT.md, etc.) for a "never commit to main" / "always use feature branch" policy before committing. Creates a branch + PR when such a policy is found; falls back to direct-to-main only when no policy is detected.
- **`/issue` Phase 2** is now conditional. A lightweight duplicate check (`gh issue list -S`) always runs. The full Explore subagent only fires when the current session lacks sufficient context (unfamiliar area, vague description).
- Bumps dev-workflow 1.2.3 → 1.2.4

Closes #131, Closes #132

## Test plan

- [ ] Verify `/reflect` Step 4 wording correctly describes the policy-check logic
- [ ] Verify `/issue` Phase 2 clearly separates the always-on duplicate check from the conditional explore step
- [ ] CI version-check passes (plugin.json and marketplace.json in sync)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
