### PR TITLE
docs(claude): expand repository structure with subdirectory paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,14 @@ This repository contains version-controlled configuration for **Claude Code CLI*
 
 ## Repository Structure
 - `plugins/core-hooks/` - Hook scripts and tests (published to marketplace)
+  - `hooks/` — hook source files
+  - `tests/` — hook tests
 - `plugins/plugin-support/` - Hook development skill, hook reference docs, and `/feedback` skill (consumer issue filing)
+  - `skills/hook-development/SKILL.md` — hook authoring guide
 - `plugins/orchestration-discipline/` - stop-momentum and delegation-guard hooks (execution discipline)
 - `plugins/dev-workflow/` - Dev workflow skills (if present)
 - Root `CLAUDE.md` - Project instructions for Claude
+- **`.claude/` is gitignored** — local runtime state only; no tracked files tracked under `.claude/`
 
 ## Self-Management Instructions for Claude
 


### PR DESCRIPTION
Moves codebase layout details (hook source/tests paths, key skill paths, `.claude/` gitignore note) from session memory into project CLAUDE.md where they belong. Session memory should not track file structure — that's a project convention, not a session-specific note.

---
*Created with assistance from Claude Code*
