### PR TITLE
feat(core-hooks): global hook logging + PermissionRequest/Notification coverage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "core-hooks",
       "description": "Productivity hooks for Claude Code: line ending normalization, gh attribution reminders, modern tool suggestions, and more",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/core-hooks/.claude-plugin/plugin.json
+++ b/plugins/core-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "core-hooks",
   "description": "Productivity hooks for Claude Code: line ending normalization, gh attribution reminders, modern tool suggestions, and more",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/core-hooks/CHANGELOG.md
+++ b/plugins/core-hooks/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.1.0] - 2026-02-27
+
+### Added
+- **PermissionRequest logging**: New `PermissionRequest` hook entry routes all permission prompts through `run-with-fallback.sh` → `log-event.py`. When `JSHOES_HOOK_LOG_DIR` is set, captures `tool_name`, `tool_input`, and `permission_suggestions` to `{session_id}.jsonl`. Observer-only — no decision returned.
+- **Notification logging**: New `Notification` hook entry captures all notification events (`permission_prompt`, `idle_prompt`, `auth_success`, `elicitation_dialog`). Same logging path as PermissionRequest. Observer-only.
+- **`log-event.py`**: Minimal observer hook shared by PermissionRequest and Notification. Outputs `{}` so `run-with-fallback.sh` handles all logging.
+
+### Changed
+- **Machine-local configuration docs**: README now documents enabling `JSHOES_HOOK_LOG_DIR` via `~/.claude/settings.json` `env` field (user scope) as the recommended approach for persistent per-machine logging — no plugin changes required.
+
 ## [1.0.0] - 2026-02-27
 
 ### Changed

--- a/plugins/core-hooks/hooks/hooks.json
+++ b/plugins/core-hooks/hooks/hooks.json
@@ -94,6 +94,26 @@
           }
         ]
       }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/run-with-fallback.sh open \"${CLAUDE_PLUGIN_ROOT}\"/hooks/log-event.py"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/run-with-fallback.sh open \"${CLAUDE_PLUGIN_ROOT}\"/hooks/log-event.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/core-hooks/hooks/log-event.py
+++ b/plugins/core-hooks/hooks/log-event.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = []
+# ///
+"""Observer hook for PermissionRequest and Notification events.
+
+Returns {} so run-with-fallback.sh captures and logs the full event input
+(including tool_name, tool_input, permission_suggestions for PermissionRequest;
+message, title, notification_type for Notification) without making any decision.
+"""
+import json
+
+print(json.dumps({}))

--- a/plugins/core-hooks/tests/test_log_event.py
+++ b/plugins/core-hooks/tests/test_log_event.py
@@ -1,0 +1,134 @@
+"""
+Unit tests for log-event.py observer hook
+
+This hook is used for PermissionRequest and Notification events. It is a
+no-op observer that outputs {} so run-with-fallback.sh can log the full
+event input to JSONL.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = Path(__file__).parent.parent / "hooks" / "log-event.py"
+WRAPPER_PATH = Path(__file__).parent.parent / "hooks" / "run-with-fallback.sh"
+
+
+def run_hook(stdin_data: str = "{}") -> dict:
+    """Run the hook directly via uv run --script and return parsed output."""
+    result = subprocess.run(
+        ["uv", "run", "--script", str(HOOK_PATH)],
+        input=stdin_data,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Hook failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+def run_via_wrapper(stdin_data: str = "{}", env: dict | None = None) -> dict:
+    """Run the hook through run-with-fallback.sh and return parsed output."""
+    merged_env = {**os.environ, **(env or {})}
+    result = subprocess.run(
+        [str(WRAPPER_PATH), "open", str(HOOK_PATH)],
+        input=stdin_data,
+        capture_output=True,
+        text=True,
+        env=merged_env,
+    )
+    assert result.returncode == 0
+    return json.loads(result.stdout.strip().splitlines()[0])
+
+
+class TestLogEvent:
+    """Tests for the log-event observer hook."""
+
+    def test_returns_empty_dict(self):
+        """Hook should return {} for any input."""
+        output = run_hook('{"session_id": "abc", "hook_event_name": "PermissionRequest"}')
+        assert output == {}, "Observer hook must return {}"
+
+    def test_returns_empty_dict_for_notification_input(self):
+        """Hook should return {} for Notification-shaped input."""
+        output = run_hook(
+            '{"session_id": "abc", "hook_event_name": "Notification", '
+            '"message": "Claude needs permission", "notification_type": "permission_prompt"}'
+        )
+        assert output == {}
+
+    def test_returns_empty_dict_for_empty_input(self):
+        """Hook should return {} even for minimal input."""
+        output = run_hook("{}")
+        assert output == {}
+
+    def test_output_is_valid_json(self):
+        """Hook output must be valid JSON."""
+        output = run_hook("{}")
+        assert isinstance(output, dict)
+
+    def test_no_permission_decision_returned(self):
+        """Observer hook must not return any permission decision."""
+        output = run_hook('{"session_id": "abc", "hook_event_name": "PermissionRequest"}')
+        assert "hookSpecificOutput" not in output, "Observer should not return hookSpecificOutput"
+
+    def test_runs_through_wrapper(self):
+        """Hook must execute successfully through run-with-fallback.sh."""
+        output = run_via_wrapper(
+            '{"session_id": "test-session", "hook_event_name": "PermissionRequest"}'
+        )
+        assert output == {}
+
+    def test_logs_permission_request_when_log_dir_set(self, tmp_path):
+        """PermissionRequest input should appear in JSONL log when JSHOES_HOOK_LOG_DIR is set."""
+        log_dir = tmp_path / "hook-logs"
+        stdin_data = json.dumps(
+            {
+                "session_id": "perm-session",
+                "hook_event_name": "PermissionRequest",
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf /"},
+                "permission_suggestions": [],
+            }
+        )
+        run_via_wrapper(stdin_data, env={"JSHOES_HOOK_LOG_DIR": str(log_dir)})
+
+        log_file = log_dir / "perm-session.jsonl"
+        assert log_file.exists(), "Log file should be created for the session"
+
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["hook"] == "log-event.py"
+        assert entry["input"]["tool_name"] == "Bash"
+        assert entry["output"] == {}
+
+    def test_logs_notification_when_log_dir_set(self, tmp_path):
+        """Notification input should appear in JSONL log when JSHOES_HOOK_LOG_DIR is set."""
+        log_dir = tmp_path / "hook-logs"
+        stdin_data = json.dumps(
+            {
+                "session_id": "notif-session",
+                "hook_event_name": "Notification",
+                "message": "Claude needs permission",
+                "notification_type": "permission_prompt",
+            }
+        )
+        run_via_wrapper(stdin_data, env={"JSHOES_HOOK_LOG_DIR": str(log_dir)})
+
+        log_file = log_dir / "notif-session.jsonl"
+        assert log_file.exists()
+
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["input"]["notification_type"] == "permission_prompt"
+        assert entry["output"] == {}
+
+
+def main():
+    """Run tests when executed as a script"""
+    exit_code = pytest.main([__file__, "-v", "--tb=short"])
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **PermissionRequest logging**: New `PermissionRequest` hook entry in `hooks.json` (catch-all, no matcher) routes all permission prompts through `run-with-fallback.sh` → `log-event.py`. When `JSHOES_HOOK_LOG_DIR` is set, captures `tool_name`, `tool_input`, and `permission_suggestions` to `{session_id}.jsonl`. Observer-only — no decision returned.
- **Notification logging**: Same pattern for `Notification` events — captures `message`, `title`, and `notification_type`. Observer-only.
- **`log-event.py`**: Minimal shared observer hook (outputs `{}`); `run-with-fallback.sh` handles all JSONL logging.
- **Machine-local configuration docs**: README now shows how to enable `JSHOES_HOOK_LOG_DIR` via `~/.claude/settings.json` `env` field (user scope) as the recommended approach — persistent across all projects on a machine, no plugin changes needed.
- **Version bump**: core-hooks 1.0.0 → 1.1.0

## Test plan

- [x] `test_log_event.py` — 8 new tests: observer returns `{}`, no decision field, runs through wrapper, logs PermissionRequest and Notification fields to JSONL
- [x] All 8 new tests pass locally
- [x] Pre-existing test failures (`test_monitor_ci_results`, `test_markdown_commit_reminder`) confirmed as sandbox `PermissionError` on `~/.claude/hook-state/` — unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
