### PR TITLE
docs(plugin-support): document real Claude Code transcript JSONL format in hook-development skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
     {
       "name": "plugin-support",
       "description": "Miscellaneous skills and documentation for Claude Code development: hook authoring guide and hook reference",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/plugin-support/.claude-plugin/plugin.json
+++ b/plugins/plugin-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-support",
   "description": "Miscellaneous skills and documentation for Claude Code development: hook authoring guide and hook reference",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/plugin-support/CHANGELOG.md
+++ b/plugins/plugin-support/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.2] - 2026-02-28
+
+### Changed
+- `hook-development` skill: added "Transcript Parsing" section documenting the real Claude Code JSONL transcript format — tool calls are nested inside `type: "assistant"` entries under `message.content[]`, not at the top level. Includes the common wrong pattern, the correct unwrapping pattern, and a warning about the test-helper trap (using wrong format in tests causes false-green results).
+
 ## [1.3.1] - 2026-02-27
 
 ### Changed


### PR DESCRIPTION
## Summary

- Add "Transcript Parsing" section to hook-development skill documenting the real Claude Code JSONL transcript format
- Tool calls are nested inside `type: "assistant"` entries under `message.content[]` — **not** at the top level as `type: "tool_use"`
- Documents the common wrong pattern, the correct unwrapping pattern, and the test-helper trap (using the wrong format in test helpers causes false-green results even when the hook is completely broken)

Lesson surfaced during the delegation-guard fix (#148), where the hook had been silently doing nothing since launch because `compute_streak` checked the wrong JSONL structure.

---
*Created with assistance from Claude Code*
