### PR TITLE
docs(orchestration-discipline): document SubagentStop crash limitation and session lifecycle [1.2.1]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -93,7 +93,7 @@
     {
       "name": "orchestration-discipline",
       "description": "Hooks that enforce execution discipline in main-session workflows: stop-momentum prevents premature session stops; delegation-guard encourages subagent delegation.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/orchestration-discipline/.claude-plugin/plugin.json
+++ b/plugins/orchestration-discipline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestration-discipline",
   "description": "Hooks that enforce execution discipline in main-session workflows: stop-momentum prevents premature session stops; delegation-guard encourages subagent delegation.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/orchestration-discipline/CHANGELOG.md
+++ b/plugins/orchestration-discipline/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.1] - 2026-03-01
+
+### Fixed
+- Document SubagentStop crash limitation: if a subagent process crashes before SubagentStop fires, `subagent_count` remains elevated and the guard is permanently suppressed for the session. No recovery mechanism; accepted as known limitation.
+- Document session lifecycle behavior: `/clear` generates a new `session_id` (state resets automatically); `/compact` preserves `session_id` (state persists correctly through compaction).
+
 ## [1.2.0] - 2026-03-01
 
 ### Added

--- a/plugins/orchestration-discipline/README.md
+++ b/plugins/orchestration-discipline/README.md
@@ -74,6 +74,10 @@ The block fires once per unbroken solo run. After it fires, subsequent tool call
 
 **Known trade-off**: While any subagent is active, the main session's guard is also suppressed. Semantically, this is acceptable — the session IS delegating during that window.
 
+**Known limitations**:
+- SubagentStop is not guaranteed to fire if a subagent process crashes (e.g. OOM, signal). If that happens, `subagent_count` remains elevated for the rest of the session and the guard is permanently suppressed. No recovery mechanism is implemented. The Claude Code docs state hooks are "deterministic" but do not explicitly cover process-level crashes.
+- `/clear` generates a new `session_id` — state resets automatically (the old file is orphaned but harmless). `/compact` preserves `session_id` — state persists correctly through compaction.
+
 #### State management
 
 Per-session state is stored in `~/.claude/hook-state/{session_id}-delegation.json`:

--- a/plugins/orchestration-discipline/hooks/delegation-guard.py
+++ b/plugins/orchestration-discipline/hooks/delegation-guard.py
@@ -38,11 +38,18 @@ Known trade-off:
   If the main session launches a background subagent and continues solo work during that
   window, the guard will not fire. This is considered semantically acceptable — the
   session IS delegating during that window.
+- SubagentStop is not guaranteed to fire if a subagent process crashes (e.g. OOM, signal).
+  If that happens, subagent_count remains elevated for the rest of the session and the
+  guard is permanently suppressed. This is an accepted known limitation — no recovery
+  mechanism is implemented. The Claude Code docs state hooks are "deterministic" but do
+  not explicitly cover process-level crashes.
 
 State management:
 - State files stored in: ~/.claude/hook-state/{session_id}-delegation.json
 - Override location: CLAUDE_HOOK_STATE_DIR environment variable
 - State fields: streak (int), block_fired (bool), subagent_count (int)
+- /clear generates a new session_id → state resets automatically (old file orphaned but harmless)
+- /compact preserves session_id → state persists correctly through compaction
 """
 import json
 import os


### PR DESCRIPTION
## Summary
- Documents that `SubagentStop` is not guaranteed to fire if a subagent process crashes (OOM, signal, etc.), leaving `subagent_count` elevated and the guard permanently suppressed for that session. Accepted as a known limitation with no recovery mechanism.
- Documents `/clear` and `/compact` session lifecycle behavior: `/clear` creates a new `session_id` (state auto-resets); `/compact` preserves `session_id` (state persists correctly).

Changes are documentation-only (module docstring + README). No behavior change.

## Test plan
- [ ] Verify CI passes (version-check workflow)
- [ ] Confirm no code changes in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
