### PR TITLE
fix(dev-workflow): replace binary confirm with routing rule in /solve Phase 3 [1.4.1]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -113,7 +113,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.4.1] - 2026-03-01
+
+### Changed
+- `/solve` Phase 3: replace binary approve/reject on the Well-scoped path with explicit routing — proceed silently when the approach is fully determined; invoke `/consult` when any implementation sub-choices exist (#147)
+
 ## [1.4.0] - 2026-02-28
 
 ### Added

--- a/plugins/dev-workflow/skills/solve/SKILL.md
+++ b/plugins/dev-workflow/skills/solve/SKILL.md
@@ -79,9 +79,12 @@ change, single-line fix). Skip directly to Phase 4 without user
 interaction.
 
 **Well-scoped** -- The issue clearly describes what to build and the
-implementation path is clear from your exploration. Briefly present your
-understanding and planned approach. Ask the user to confirm, then proceed
-to Phase 4.
+implementation path is clear from your exploration. If the approach is
+fully determined (no sub-choices, no trade-offs worth surfacing), proceed
+directly to Phase 4 and note your approach in passing. If the approach
+contains any implementation sub-choices (even with clear recommendations
+for each), invoke `/consult` via the Skill tool -- never collapse
+sub-choices into a binary confirm/reject.
 
 **Needs design decisions** -- There are open questions about approach,
 trade-offs, or how the solution fits into the existing architecture.


### PR DESCRIPTION
## Summary
- Removes the binary "confirm?" prompt from `/solve` Phase 3 Well-scoped path
- Well-scoped issues with fully determined approaches now proceed silently to Phase 4
- Well-scoped issues with any implementation sub-choices now invoke `/consult` via the Skill tool

## Test plan
- [ ] Manually verify the updated Phase 3 wording reads correctly in `plugins/dev-workflow/skills/solve/SKILL.md`
- [ ] Confirm `plugin.json` version is `1.4.1`
- [ ] Confirm `CHANGELOG.md` has a `[1.4.1]` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #147
