### PR TITLE
docs(dev-workflow): document AskUserQuestion 4-option limit in /session Phase 1 [1.4.2]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -113,7 +113,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.4.2] - 2026-03-01
+
+### Changed
+- `/session` Phase 1: document AskUserQuestion 4-option limit and handling rule for triage queues with >4 items
+
 ## [1.4.1] - 2026-03-01
 
 ### Changed

--- a/plugins/dev-workflow/skills/session/SKILL.md
+++ b/plugins/dev-workflow/skills/session/SKILL.md
@@ -49,7 +49,10 @@ After the triage agent returns, present the results in two steps:
    option per queue item. Each option label should be the issue number +
    one-line description; the option description should add one sentence of
    essential context. The user can scroll up to the full summary if they
-   need more detail. Keep the question field brief.
+   need more detail. Keep the question field brief. AskUserQuestion allows
+   at most 4 options. If the queue has more than 4 items, present only the
+   top 4 in the interactive question; the full ranked list in the printed
+   summary above it gives the user complete context.
 
 ## Phase 2: Solve
 


### PR DESCRIPTION
## Summary
- Documents the AskUserQuestion 4-option limit in /session Phase 1 triage
- When triage surfaces >4 items, present top 4 in the interactive question; full list goes in the printed summary

## Context
Surfaced during a /reflect pass after a session where triage found 5 open issues and hit the validation error silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
