### PR TITLE
fix(core-hooks): add CLAUDE_HOOK_STATE_DIR support for sandbox compat

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "core-hooks",
       "description": "Productivity hooks for Claude Code: line ending normalization, gh attribution reminders, modern tool suggestions, and more",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/core-hooks/.claude-plugin/plugin.json
+++ b/plugins/core-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "core-hooks",
   "description": "Productivity hooks for Claude Code: line ending normalization, gh attribution reminders, modern tool suggestions, and more",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/core-hooks/CHANGELOG.md
+++ b/plugins/core-hooks/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.1] - 2026-03-01
+
+### Fixed
+- Add `CLAUDE_HOOK_STATE_DIR` env var support to markdown-commit-reminder and monitor-ci-results hooks for sandbox compatibility
+- Update test files to use TMPDIR-based state directory instead of hardcoded `~/.claude/hook-state/`
+
 ## [1.1.0] - 2026-02-27
 
 ### Added

--- a/plugins/core-hooks/hooks/markdown-commit-reminder.py
+++ b/plugins/core-hooks/hooks/markdown-commit-reminder.py
@@ -68,6 +68,7 @@ Limitations:
 - Only monitors Bash tool (not direct git operations from other tools)
 """
 import json
+import os
 import sys
 import re
 import time
@@ -76,8 +77,9 @@ from pathlib import Path
 # Cooldown period in seconds (5 minutes)
 COOLDOWN_PERIOD = 300
 
-# State file location
-STATE_DIR = Path.home() / ".claude" / "hook-state"
+# State directory location
+_state_dir_env = os.environ.get("CLAUDE_HOOK_STATE_DIR")
+STATE_DIR = Path(_state_dir_env) if _state_dir_env else Path.home() / ".claude" / "hook-state"
 
 # Patterns to detect markdown file involvement in git commands
 MD_FILE_PATTERN = r'\.md(?:\s|$|"|\')'

--- a/plugins/core-hooks/hooks/monitor-ci-results.py
+++ b/plugins/core-hooks/hooks/monitor-ci-results.py
@@ -65,7 +65,8 @@ from pathlib import Path
 COOLDOWN_PERIOD = 120
 
 # State file location
-STATE_DIR = Path.home() / ".claude" / "hook-state"
+_state_dir_env = os.environ.get("CLAUDE_HOOK_STATE_DIR")
+STATE_DIR = Path(_state_dir_env) if _state_dir_env else Path.home() / ".claude" / "hook-state"
 
 # Patterns to detect push and PR creation
 GIT_PUSH_PATTERN = r'git\s+push'

--- a/plugins/core-hooks/tests/test_markdown_commit_reminder.py
+++ b/plugins/core-hooks/tests/test_markdown_commit_reminder.py
@@ -5,6 +5,7 @@ This test suite validates that the hook properly detects git commands
 involving markdown files and provides appropriate guidance.
 """
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -12,6 +13,9 @@ import pytest
 
 # Path to the hook script
 HOOK_PATH = Path(__file__).parent.parent / "hooks" / "markdown-commit-reminder.py"
+
+# Test state directory (redirects away from ~/.claude/hook-state/ for sandbox compat)
+TEST_STATE_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "claude-hook-test-state"
 
 
 def run_hook(tool_name: str, command: str, clear_cooldown: bool = True) -> dict:
@@ -34,16 +38,20 @@ def run_hook(tool_name: str, command: str, clear_cooldown: bool = True) -> dict:
 
     # Clear cooldown state if requested
     if clear_cooldown:
-        state_dir = Path.home() / ".claude" / "hook-state"
-        state_file = state_dir / "markdown-commit-cooldown-test-session-abc123"
+        state_file = TEST_STATE_DIR / "markdown-commit-cooldown-test-session-abc123"
         if state_file.exists():
             state_file.unlink()
+
+    env = os.environ.copy()
+    env["CLAUDE_HOOK_STATE_DIR"] = str(TEST_STATE_DIR)
+    TEST_STATE_DIR.mkdir(parents=True, exist_ok=True)
 
     result = subprocess.run(
         ["uv", "run", "--script", str(HOOK_PATH)],
         input=json.dumps(input_data),
         capture_output=True,
-        text=True
+        text=True,
+        env=env
     )
 
     if result.returncode not in [0, 1]:  # 0 = success, 1 = expected error with {}
@@ -176,8 +184,7 @@ class TestCooldownMechanism:
 
     def test_cooldown_state_file_created(self):
         """Cooldown state file should be created"""
-        state_dir = Path.home() / ".claude" / "hook-state"
-        state_file = state_dir / "markdown-commit-cooldown-test-session-abc123"
+        state_file = TEST_STATE_DIR / "markdown-commit-cooldown-test-session-abc123"
 
         # Clear state first
         if state_file.exists():

--- a/plugins/core-hooks/tests/test_monitor_ci_results.py
+++ b/plugins/core-hooks/tests/test_monitor_ci_results.py
@@ -22,6 +22,9 @@ import pytest
 # Path to the hook script
 HOOK_PATH = Path(__file__).parent.parent / "hooks" / "monitor-ci-results.py"
 
+# Test state directory (redirects away from ~/.claude/hook-state/ for sandbox compat)
+TEST_STATE_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "claude-hook-test-state"
+
 
 def run_hook(
     tool_name: str,
@@ -54,10 +57,13 @@ def run_hook(
 
     # Clear cooldown state if requested
     if clear_cooldown:
-        state_dir = Path.home() / ".claude" / "hook-state"
-        state_file = state_dir / "monitor-ci-cooldown-test-session-abc123"
+        state_file = TEST_STATE_DIR / "monitor-ci-cooldown-test-session-abc123"
         if state_file.exists():
             state_file.unlink()
+
+    env = os.environ.copy()
+    env["CLAUDE_HOOK_STATE_DIR"] = str(TEST_STATE_DIR)
+    TEST_STATE_DIR.mkdir(parents=True, exist_ok=True)
 
     # Create a temp directory structure to simulate workflows
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -75,7 +81,8 @@ def run_hook(
                 ["uv", "run", "--script", str(HOOK_PATH)],
                 input=json.dumps(input_data),
                 capture_output=True,
-                text=True
+                text=True,
+                env=env
             )
 
             if result.returncode not in [0, 1]:  # 0 = success, 1 = expected error with {}
@@ -187,8 +194,7 @@ class TestCooldownMechanism:
 
     def test_cooldown_state_file_created(self):
         """Cooldown state file should be created"""
-        state_dir = Path.home() / ".claude" / "hook-state"
-        state_file = state_dir / "monitor-ci-cooldown-test-session-abc123"
+        state_file = TEST_STATE_DIR / "monitor-ci-cooldown-test-session-abc123"
 
         # Clear state first
         if state_file.exists():


### PR DESCRIPTION
## Summary
- Add `CLAUDE_HOOK_STATE_DIR` env var support to `markdown-commit-reminder` and `monitor-ci-results` hooks, matching the pattern already used by `gh-authorship-attribution`
- Update both test files to use `TEST_STATE_DIR` (TMPDIR-based) instead of hardcoded `~/.claude/hook-state/` paths
- Fixes 81 test failures caused by sandbox permission errors on `~/.claude/hook-state/`

Closes #165

## Test plan
- [ ] All 520 core-hooks tests pass locally
- [ ] CI passes (version-check + test workflows)
- [ ] Hooks still work in production (env var absent → falls back to default path)

Generated with [Claude Code](https://claude.com/claude-code)
