### PR TITLE
feat(delegation-guard): support per-project config for exempt tools [1.1.0]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -71,7 +71,7 @@
     {
       "name": "delegation-guard",
       "description": "PreToolUse hook that encourages main-session delegation to subagents via escalating reminders.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/delegation-guard/.claude-plugin/plugin.json
+++ b/plugins/delegation-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "delegation-guard",
   "description": "PreToolUse hook that encourages main-session delegation to subagents via escalating reminders.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/delegation-guard/CHANGELOG.md
+++ b/plugins/delegation-guard/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.0] - 2026-03-01
+
+### Added
+- Per-project configuration via `.claude/delegation-guard.json`
+- `exempt_tools` config field to add project-specific tool exemptions (merged with defaults)
+
 ## [1.0.0] - 2026-03-01
 
 ### Added

--- a/plugins/delegation-guard/README.md
+++ b/plugins/delegation-guard/README.md
@@ -33,6 +33,26 @@ These tools neither increment nor reset the streak:
 - `TaskCreate`, `TaskUpdate`, `TaskGet`, `TaskList` — task list management
 - `EnterPlanMode`, `ExitPlanMode` — planning mode transitions
 
+### Per-project configuration
+
+You can extend the exempt tools list on a per-project basis by creating a `.claude/delegation-guard.json` config file:
+
+```json
+{
+  "exempt_tools": ["ToolName1", "ToolName2"]
+}
+```
+
+Project-specific exemptions are **merged** with the defaults (not a replacement). Example:
+
+```json
+{
+  "exempt_tools": ["mcp__assistant__send_message", "mcp__custom__tool"]
+}
+```
+
+This allows you to exempt project-specific tools (e.g., MCP integrations) without overriding the built-in exempt tools.
+
 ## Subagent detection
 
 The hook registers for `SubagentStart` and `SubagentStop` events. When a subagent starts, a reference counter (`subagent_count`) increments; when it stops, it decrements (floor 0). While `subagent_count > 0`, all `PreToolUse` calls pass through silently — subagents receive no blocks or advisory messages. The hard block re-arms when the count returns to 0 (the Agent call that spawned the subagent already reset `streak=0`).

--- a/plugins/delegation-guard/hooks/delegation-guard.py
+++ b/plugins/delegation-guard/hooks/delegation-guard.py
@@ -73,6 +73,20 @@ EXEMPT_TOOLS = {
 }
 
 
+def load_project_config() -> dict:
+    """Load per-project delegation-guard config from .claude/delegation-guard.json.
+
+    Returns a dict with optional 'exempt_tools' key (list of strings).
+    Returns empty dict on file not found, invalid JSON, or missing keys.
+    """
+    config_path = Path.cwd() / ".claude" / "delegation-guard.json"
+    try:
+        with open(config_path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
 def get_state_file(session_id: str) -> Path:
     """Return the path to the state file for this session."""
     return STATE_DIR / f"{session_id}-delegation.json"
@@ -195,7 +209,11 @@ def main():
             print("{}")
             sys.exit(0)
 
-        if tool_name in EXEMPT_TOOLS:
+        # Merge project config exempt_tools with defaults
+        config = load_project_config()
+        extra_exempt = set(config.get("exempt_tools", []))
+        exempt = EXEMPT_TOOLS | extra_exempt
+        if tool_name in exempt:
             # Neutral — no state change
             print("{}")
             sys.exit(0)

--- a/plugins/delegation-guard/tests/test_delegation_guard.py
+++ b/plugins/delegation-guard/tests/test_delegation_guard.py
@@ -33,8 +33,17 @@ def run_hook(
     session_id: str = DEFAULT_SESSION_ID,
     clear_state: bool = True,
     transcript_path: str = "",
+    cwd: str = "",
 ) -> dict:
-    """Run the delegation-guard hook and return parsed JSON output."""
+    """Run the delegation-guard hook and return parsed JSON output.
+
+    Args:
+        tool_name: Name of the tool being called
+        session_id: Session ID for state tracking
+        clear_state: Whether to clear state before running
+        transcript_path: Path to transcript (optional)
+        cwd: Working directory for the hook (optional)
+    """
     if clear_state:
         state_file = TEST_STATE_DIR / f"{session_id}-delegation.json"
         if state_file.exists():
@@ -58,6 +67,7 @@ def run_hook(
         capture_output=True,
         text=True,
         env=env,
+        cwd=cwd if cwd else None,
     )
 
     if result.returncode not in [0, 1]:
@@ -541,6 +551,71 @@ class TestStateFile:
         assert "offset" not in state
         assert "task_calls" not in state
         assert "advisory_fired" not in state
+
+
+# ---------------------------------------------------------------------------
+# Per-project config
+# ---------------------------------------------------------------------------
+
+class TestProjectConfig:
+    """Per-project config file (.claude/delegation-guard.json) support."""
+
+    def test_extra_exempt_tool_from_config(self, tmp_path):
+        """Project config exempt_tools are recognized and treated as exempt."""
+        # Create config in temp directory
+        config_dir = tmp_path / ".claude"
+        config_dir.mkdir()
+        config_file = config_dir / "delegation-guard.json"
+        config_file.write_text(json.dumps({"exempt_tools": ["mcp__assistant__send_message"]}))
+
+        # Run hook with custom tool from config, from that CWD
+        output = run_hook("mcp__assistant__send_message", clear_state=True, cwd=str(tmp_path))
+        assert output == {}, "Config exempt tool should not trigger block"
+
+    def test_missing_config_uses_defaults(self, tmp_path):
+        """Without config file, default exempt tools still work."""
+        # Create empty temp directory (no config file)
+        output = run_hook("Skill", clear_state=True, cwd=str(tmp_path))
+        assert output == {}, "Default exempt tools should work without config file"
+
+    def test_corrupt_json_uses_defaults(self, tmp_path):
+        """Corrupt config JSON falls back to defaults."""
+        # Create config with invalid JSON
+        config_dir = tmp_path / ".claude"
+        config_dir.mkdir()
+        config_file = config_dir / "delegation-guard.json"
+        config_file.write_text("not valid json {{{{")
+
+        # Run hook with default exempt tool
+        output = run_hook("Skill", clear_state=True, cwd=str(tmp_path))
+        assert output == {}, "Corrupt config should fall back to defaults"
+
+    def test_empty_exempt_tools_uses_defaults(self, tmp_path):
+        """Config with empty exempt_tools list still uses defaults."""
+        # Create config with empty list
+        config_dir = tmp_path / ".claude"
+        config_dir.mkdir()
+        config_file = config_dir / "delegation-guard.json"
+        config_file.write_text(json.dumps({"exempt_tools": []}))
+
+        # Run hook with default exempt tool
+        output = run_hook("Skill", clear_state=True, cwd=str(tmp_path))
+        assert output == {}, "Empty config should still use default exemptions"
+
+    def test_config_merges_with_defaults(self, tmp_path):
+        """Config exempt_tools are additive to defaults (not replacement)."""
+        # Create config with extra tool
+        config_dir = tmp_path / ".claude"
+        config_dir.mkdir()
+        config_file = config_dir / "delegation-guard.json"
+        config_file.write_text(json.dumps({"exempt_tools": ["CustomTool"]}))
+
+        # Verify both defaults and config tools are exempt
+        output_default = run_hook("Skill", clear_state=True, cwd=str(tmp_path))
+        assert output_default == {}, "Default tool should still be exempt"
+
+        output_custom = run_hook("CustomTool", clear_state=False, cwd=str(tmp_path))
+        assert output_custom == {}, "Config tool should be exempt"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add per-project configuration support for delegation-guard via `.claude/delegation-guard.json`. Projects can now define custom tool exemptions that merge with the built-in defaults, enabling exemption of project-specific tools (e.g., MCP integrations) without overriding standard exemptions.

## Changes

- **Hook**: Added `load_project_config()` function to read `.claude/delegation-guard.json` with graceful fallback
- **PreToolUse handler**: Merged project config `exempt_tools` with default EXEMPT_TOOLS before checking tool name
- **Tests**: Added 5 new tests (TestProjectConfig class) covering config loading, missing/corrupt files, and merging behavior
- **Docs**: Added "Per-project Configuration" section to README.md with schema and examples
- **Version**: Bumped to 1.1.0 with CHANGELOG entry

## Test plan

- [x] All 56 tests pass (51 existing + 5 new config tests)
- [x] Config exempt tools are recognized as exempt
- [x] Missing config file falls back to defaults
- [x] Corrupt JSON gracefully returns to defaults
- [x] Project and default exemptions are additive (not replacement)

Closes #171
