### PR TITLE
fix(dev-workflow): bump to 2.1.1 for agents field removal

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,7 +107,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.1] - 2026-03-07
+
+### Fixed
+- Removed invalid `agents` field from plugin.json that prevented the plugin from loading
+- Updated SKILL.md scanner invocation to read agent instructions from file instead of referencing unsupported bundled agent
+
 ## [2.1.0] - 2026-03-07
 
 ### Changed


### PR DESCRIPTION
Patch version bump for the plugin.json fix in #185. CI requires a version bump when plugin files change.