### PR TITLE
fix(dev-workflow): don't delete scan files before scanners read them [2.1.2]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,7 +107,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.1.2] - 2026-03-07
+
+### Fixed
+- Fixed atexit cleanup handler that deleted intermediate scan files before scanner agents could read them. Cleanup now only fires on abnormal exit (crashes); normal exit leaves files for scanners, with main agent running explicit cleanup after.
+
 ## [2.1.1] - 2026-03-07
 
 ### Fixed

--- a/plugins/dev-workflow/skills/reflect/scripts/reflect-filter.py
+++ b/plugins/dev-workflow/skills/reflect/scripts/reflect-filter.py
@@ -14,6 +14,10 @@ import sys
 from pathlib import Path
 
 
+# Flag to distinguish normal exit from crash
+_normal_exit = False
+
+
 def derive_project_dir(pwd: str) -> str:
     """Derive project directory from $PWD."""
     return os.path.join(
@@ -299,7 +303,12 @@ def extract_nonce_prefix(nonce: str) -> str:
 
 
 def cleanup_reflect_files(nonce_prefix: str):
-    """Cleanup handler: delete all .reflect-scan-* files with matching prefix."""
+    """Cleanup handler: delete all .reflect-scan-* files with matching prefix.
+    Only cleans up on abnormal exit (crash). On normal exit, files are left for
+    scanners to read; main agent cleans up after scanners complete.
+    """
+    if _normal_exit:
+        return
     pattern = f".reflect-scan-{nonce_prefix}-*.jsonl"
     for filepath in glob.glob(pattern):
         try:
@@ -405,6 +414,8 @@ def main():
         print("## Cleanup")
         print(f"rm -f .reflect-scan-{nonce_prefix}-*.jsonl")
 
+        global _normal_exit
+        _normal_exit = True
         return 0
 
     except Exception as e:


### PR DESCRIPTION
Fixes atexit cleanup that deleted intermediate files on normal exit. Scanners couldn't read them.