### PR TITLE
fix(dev-workflow): use subagent_type for scanner invocation [2.1.3]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,7 +107,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.1.3] - 2026-03-07
+
+### Fixed
+- `/reflect` SKILL.md: scanner agents now invoked via `subagent_type: "dev-workflow:reflect-scanner"` with assignment-only prompts instead of redundantly passing checklists. Ensures consistent scanner behavior.
+
 ## [2.1.2] - 2026-03-07
 
 ### Fixed


### PR DESCRIPTION
Scanner prompts now contain only the assignment. Checklists loaded from bundled agent definition.
