### PR TITLE
feat(delegation-guard): unblocked tools + message audit [1.2.0]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -71,7 +71,7 @@
     {
       "name": "delegation-guard",
       "description": "PreToolUse hook that encourages main-session delegation to subagents via escalating reminders.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/delegation-guard/.claude-plugin/plugin.json
+++ b/plugins/delegation-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "delegation-guard",
   "description": "PreToolUse hook that encourages main-session delegation to subagents via escalating reminders.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/delegation-guard/CHANGELOG.md
+++ b/plugins/delegation-guard/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.2.0] - 2026-03-08
+
+### Added
+- `unblocked_tools` category — tools that are never hard-blocked but still count toward the advisory streak
+- Default unblocked tools: Read, Glob, Grep (essential for code understanding)
+- Unblocked tools fire an advisory at streak=0 instead of being hard-blocked, then increment to streak=1
+- Per-project configuration for `unblocked_tools` via `.claude/delegation-guard.json` (merged with defaults, same pattern as `exempt_tools`)
+
 ## [1.1.0] - 2026-03-01
 
 ### Added

--- a/plugins/delegation-guard/README.md
+++ b/plugins/delegation-guard/README.md
@@ -12,15 +12,15 @@ Intercepts every tool call before it runs. Blocks the first solo tool call after
 
 | Streak | Action |
 |--------|--------|
-| 0 (block not yet fired) | **Block** — hard stop via `permissionDecision: "deny"`. The blocked call does not count toward the streak. |
-| 1 | Silent — first executed call after the block |
-| 2 | Advisory — mild reminder |
-| 4 | Advisory — stronger |
-| 8 | Advisory — urgent |
-| 16 | Advisory — critical |
+| 0 (block not yet fired) | **Block** — hard stop via `permissionDecision: "deny"`. The blocked call does not count toward the streak. Unblocked tools skip the deny, set block_fired=True, increment to streak=1, and fire an advisory instead. |
+| 1 | Silent — first executed call after the block (or first unblocked tool call) |
+| 2 | Advisory — reminder |
+| 3 | Advisory — advisory |
+| 5 | Advisory — warning |
+| 8+ | Advisory — critical |
 | Task/Agent call | Reset — streak returns to 0 and the block re-arms |
 
-Streaks at non-power-of-2 values (3, 5, 6, 7, 9, …) pass through silently.
+Streaks at non-Fibonacci values (4, 6, 7, 9, 10, …) pass through silently. Advisory fires at Fibonacci numbers >= 2: 2, 3, 5, 8, 13, 21, 34, …
 
 The block fires once per unbroken solo run. After it fires, subsequent tool calls increment the streak and receive advisory messages — but are not blocked. A Task or Agent call resets the streak to 0 and re-arms the block so the cycle can start again.
 
@@ -33,25 +33,39 @@ These tools neither increment nor reset the streak:
 - `TaskCreate`, `TaskUpdate`, `TaskGet`, `TaskList` — task list management
 - `EnterPlanMode`, `ExitPlanMode` — planning mode transitions
 
+## Unblocked tools
+
+These tools are never hard-blocked but still count toward the advisory streak:
+
+- `Read` — read-only file operations
+- `Glob` — file search (read-only)
+- `Grep` — content search (read-only)
+
+When an unblocked tool is called at streak=0 (before the block has fired), it behaves differently from normal tools: instead of being blocked, it skips the deny, sets `block_fired=True`, increments the streak to 1, and fires an advisory message. After `block_fired=True`, unblocked tools behave identically to normal tools — they pass through, increment the streak, and trigger advisories at Fibonacci values (2, 3, 5, 8, 13, 21, …).
+
+This design acknowledges that read-only operations are essential for understanding code context, so they receive an advisory rather than a hard block on first use.
+
 ### Per-project configuration
 
-You can extend the exempt tools list on a per-project basis by creating a `.claude/delegation-guard.json` config file:
+You can extend both the exempt and unblocked tools lists on a per-project basis by creating a `.claude/delegation-guard.json` config file:
 
 ```json
 {
-  "exempt_tools": ["ToolName1", "ToolName2"]
+  "exempt_tools": ["ToolName1", "ToolName2"],
+  "unblocked_tools": ["ToolName3", "ToolName4"]
 }
 ```
 
-Project-specific exemptions are **merged** with the defaults (not a replacement). Example:
+Both `exempt_tools` and `unblocked_tools` are **merged** with the defaults (not a replacement). Example:
 
 ```json
 {
-  "exempt_tools": ["mcp__assistant__send_message", "mcp__custom__tool"]
+  "exempt_tools": ["mcp__assistant__send_message"],
+  "unblocked_tools": ["mcp__custom__read_tool"]
 }
 ```
 
-This allows you to exempt project-specific tools (e.g., MCP integrations) without overriding the built-in exempt tools.
+This allows you to exempt or unblock project-specific tools (e.g., MCP integrations) without overriding the built-in tool lists.
 
 ## Subagent detection
 

--- a/plugins/delegation-guard/hooks/delegation-guard.py
+++ b/plugins/delegation-guard/hooks/delegation-guard.py
@@ -15,14 +15,16 @@ Behavior (PreToolUse):
   Subagents share the parent's session_id and state file; without this guard they
   would receive confusing "delegate to a subagent" messages during their own work.
 - When streak == 0 and block_fired is False (i.e., at the start of a potential solo run):
-  Block the incoming non-Task/Agent tool call with permissionDecision: "deny". The blocked
-  call does NOT increment the streak — only executed calls count.
-- After the block fires (block_fired=True), subsequent non-Task/Agent calls increment streak.
-  Escalating advisory messages fire at streak 2, 4, 8, 16, ... (powers of 2 >= 2).
+  - Task/Agent tools: reset streak and re-arm block (always pass through)
+  - Exempt tools (e.g. Skill, AskUserQuestion, TaskCreate, ...): neutral, no state change
+  - Unblocked tools (Read, Glob, Grep, configurable): set block_fired=True, increment
+    streak to 1, fire advisory (never hard-blocked)
+  - All other tools: hard-stop with permissionDecision: "deny"
+- After the block fires (block_fired=True), all tool calls (normal and unblocked) increment
+  streak. Escalating advisory messages fire at Fibonacci numbers >= 2 (2, 3, 5, 8, 13, 21, ...).
+  Unblocked tools also fire a distinct advisory at streak=1 (only possible on their first call).
 - A Task or Agent call resets streak to 0 and re-arms the block (block_fired=False).
   ("Agent" is the name used by Claude Code v2.1.63+; "Task" is the legacy name.)
-- Exempt tools (e.g. Skill, AskUserQuestion, TaskCreate, ...) are neutral — they neither
-  increment streak nor reset it.
 
 Behavior (SubagentStart):
 - Increments subagent_count. While count > 0, PreToolUse passes through silently.
@@ -72,11 +74,14 @@ EXEMPT_TOOLS = {
     "ExitPlanMode",
 }
 
+# Tools that are never hard-blocked on first call; instead fire advisory at streak=1
+UNBLOCKED_TOOLS = {"Read", "Glob", "Grep"}
+
 
 def load_project_config() -> dict:
     """Load per-project delegation-guard config from .claude/delegation-guard.json.
 
-    Returns a dict with optional 'exempt_tools' key (list of strings).
+    Returns a dict with optional 'exempt_tools' and 'unblocked_tools' keys (lists of strings).
     Returns empty dict on file not found, invalid JSON, or missing keys.
     """
     config_path = Path.cwd() / ".claude" / "delegation-guard.json"
@@ -125,46 +130,56 @@ def write_state(session_id: str, state: dict) -> None:
 
 
 def is_backoff_point(streak: int) -> bool:
-    """Return True if streak is a power of 2 >= 2 (i.e., 2, 4, 8, 16, ...)."""
-    return streak >= 2 and (streak & (streak - 1)) == 0
+    """Return True if streak is a Fibonacci number >= 2 (i.e., 2, 3, 5, 8, 13, 21, ...)."""
+    if streak < 2:
+        return False
+    a, b = 1, 2
+    while b < streak:
+        a, b = b, a + b
+    return b == streak
 
 
 def build_block_message() -> str:
     """Build the one-time hard-stop block message for streak=0."""
     return (
-        "Delegation check: you are about to make a solo tool call. "
-        "This is a one-time hard stop — delegate to a Task subagent instead. "
-        "After this, reminders will be advisory-only (non-blocking). "
-        "Use the Task tool to spawn a subagent, then synthesize what it returns."
+        "Delegation check: this tool call was blocked. "
+        "Consider whether this work should be delegated to an Agent subagent instead of done solo. "
+        "This is a one-time block — if this call is genuinely a quick one-off, "
+        "retry it and the block won't fire again. Future reminders are advisory-only."
+    )
+
+
+def build_streak1_message() -> str:
+    """Build the distinct advisory for unblocked tools at streak=1."""
+    return (
+        "Delegation reminder [streak=1]: this call was allowed through without blocking. "
+        "Before making more solo calls, consider whether this work should be "
+        "delegated to an Agent subagent."
     )
 
 
 def build_advisory_message(streak: int) -> str:
     """Build an escalating advisory message for the given streak level."""
     if streak <= 2:
-        tone = (
-            f"Delegation reminder [streak={streak}]: you have made {streak} consecutive "
-            f"solo tool calls. Consider delegating this work to a Task subagent."
+        return (
+            f"Delegation reminder [streak={streak}]: {streak} consecutive "
+            f"solo calls. Consider delegating to an Agent subagent."
         )
-    elif streak <= 4:
-        tone = (
-            f"Delegation advisory [streak={streak}]: {streak} consecutive solo tool calls. "
-            f"Main session context is non-renewable — push reads, research, and implementation "
-            f"to subagents. Use the Task tool."
+    elif streak <= 3:
+        return (
+            f"Delegation advisory [streak={streak}]: {streak} consecutive "
+            f"solo calls. Consider delegating to an Agent subagent."
         )
-    elif streak <= 8:
-        tone = (
-            f"Delegation warning [streak={streak}]: {streak} consecutive solo tool calls. "
-            f"Main session capacity is depleting. This work belongs in a subagent. "
-            f"Spawn a Task now and synthesize the result."
+    elif streak <= 5:
+        return (
+            f"Delegation warning [streak={streak}]: {streak} consecutive "
+            f"solo calls. Consider delegating to an Agent subagent."
         )
     else:
-        tone = (
-            f"DELEGATION CRITICAL [streak={streak}]: {streak} consecutive solo tool calls. "
-            f"You are consuming irreplaceable main session context. Stop and delegate immediately. "
-            f"Use the Task tool to spawn a subagent for any further work."
+        return (
+            f"DELEGATION CRITICAL [streak={streak}]: {streak} consecutive "
+            f"solo calls. Consider delegating to an Agent subagent."
         )
-    return tone
 
 
 def main():
@@ -209,7 +224,7 @@ def main():
             print("{}")
             sys.exit(0)
 
-        # Merge project config exempt_tools with defaults
+        # Merge project config exempt_tools and unblocked_tools with defaults
         config = load_project_config()
         extra_exempt = set(config.get("exempt_tools", []))
         exempt = EXEMPT_TOOLS | extra_exempt
@@ -223,20 +238,38 @@ def main():
             print("{}")
             sys.exit(0)
 
+        # Merge unblocked_tools defaults with project config
+        extra_unblocked = set(config.get("unblocked_tools", []))
+        unblocked = UNBLOCKED_TOOLS | extra_unblocked
+
         # Non-Task/Agent, non-exempt tool call
         if streak == 0 and not block_fired:
-            # First solo call after a Task or session start: hard stop
-            # Blocked call does NOT increment streak — only executed calls count
-            write_state(session_id, {"streak": 0, "block_fired": True, "subagent_count": subagent_count})
-            output = {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": build_block_message(),
+            # First solo call after a Task or session start
+            if tool_name in unblocked:
+                # Unblocked tools: never hard-blocked, but fire advisory at streak=1
+                new_streak = 1
+                write_state(session_id, {"streak": new_streak, "block_fired": True, "subagent_count": subagent_count})
+                output = {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "additionalContext": build_streak1_message(),
+                    }
                 }
-            }
-            print(json.dumps(output))
-            sys.exit(0)
+                print(json.dumps(output))
+                sys.exit(0)
+            else:
+                # Normal tools: hard stop
+                # Blocked call does NOT increment streak — only executed calls count
+                write_state(session_id, {"streak": 0, "block_fired": True, "subagent_count": subagent_count})
+                output = {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": build_block_message(),
+                    }
+                }
+                print(json.dumps(output))
+                sys.exit(0)
 
         # Block already fired — this call executes; increment streak
         new_streak = streak + 1

--- a/plugins/delegation-guard/tests/test_delegation_guard.py
+++ b/plugins/delegation-guard/tests/test_delegation_guard.py
@@ -8,7 +8,8 @@ Behavioral model:
 - First solo call (streak==0, block_fired==False): BLOCK via permissionDecision: "deny".
   Blocked call does NOT increment streak.
 - After block fires (block_fired=True): subsequent non-Task/Agent calls increment streak.
-  Escalating advisory fires at streak 2, 4, 8, 16, ... (powers of 2 >= 2).
+  Escalating advisory fires at Fibonacci numbers >= 2 (2, 3, 5, 8, 13, 21, ...).
+  Unblocked tools also fire a distinct advisory at streak=1 (only on their first call).
 - Task or Agent call: resets streak to 0 and re-arms block (block_fired=False).
   ("Agent" is the name used by Claude Code v2.1.63+; "Task" is the legacy name.)
 - Exempt tools (Skill, AskUserQuestion, TaskCreate, etc.): neutral, no state change.
@@ -212,7 +213,7 @@ class TestStreakCounting:
 # ---------------------------------------------------------------------------
 
 class TestEscalatingAdvisories:
-    """Advisory fires at streak 2, 4, 8, 16 (powers of 2 >= 2); silent at all others."""
+    """Advisory fires at Fibonacci numbers >= 2 (2, 3, 5, 8, 13, 21, ...); silent at all others."""
 
     def _reach_streak(self, n: int) -> dict:
         """Advance to the given streak level and return the output from the final call."""
@@ -223,51 +224,51 @@ class TestEscalatingAdvisories:
         return output
 
     def test_advisory_fires_at_streak_2(self):
-        """Advisory must fire when streak reaches 2."""
+        """Advisory must fire when streak reaches 2 (Fibonacci)."""
         output = self._reach_streak(2)
         assert "hookSpecificOutput" in output
         hook_out = output["hookSpecificOutput"]
         assert "additionalContext" in hook_out
         assert hook_out.get("permissionDecision") != "deny"
 
-    def test_advisory_fires_at_streak_4(self):
-        """Advisory must fire when streak reaches 4."""
-        output = self._reach_streak(4)
+    def test_advisory_fires_at_streak_3(self):
+        """Advisory must fire when streak reaches 3 (Fibonacci)."""
+        output = self._reach_streak(3)
+        assert "hookSpecificOutput" in output
+        assert "additionalContext" in output["hookSpecificOutput"]
+
+    def test_advisory_fires_at_streak_5(self):
+        """Advisory must fire when streak reaches 5 (Fibonacci)."""
+        output = self._reach_streak(5)
         assert "hookSpecificOutput" in output
         assert "additionalContext" in output["hookSpecificOutput"]
 
     def test_advisory_fires_at_streak_8(self):
-        """Advisory must fire when streak reaches 8."""
+        """Advisory must fire when streak reaches 8 (Fibonacci)."""
         output = self._reach_streak(8)
         assert "hookSpecificOutput" in output
         assert "additionalContext" in output["hookSpecificOutput"]
 
-    def test_advisory_fires_at_streak_16(self):
-        """Advisory must fire when streak reaches 16."""
-        output = self._reach_streak(16)
-        assert "hookSpecificOutput" in output
-        assert "additionalContext" in output["hookSpecificOutput"]
-
     def test_silent_at_streak_1(self):
-        """First executed call (streak=1) must be silent."""
+        """First executed call by normal tool (streak=1) must be silent."""
         run_hook("Bash", clear_state=True)          # block fires
         output = run_hook("Bash", clear_state=False) # streak → 1
         assert output == {}, f"Expected silent at streak=1, got: {output}"
 
-    def test_silent_at_streak_3(self):
-        """Streak=3 is not a power of 2, must be silent."""
-        output = self._reach_streak(3)
-        assert output == {}, f"Expected silent at streak=3, got: {output}"
-
-    def test_silent_at_streak_5(self):
-        """Streak=5 is not a power of 2, must be silent."""
-        output = self._reach_streak(5)
-        assert output == {}, f"Expected silent at streak=5, got: {output}"
+    def test_silent_at_streak_4(self):
+        """Streak=4 is not a Fibonacci number, must be silent."""
+        output = self._reach_streak(4)
+        assert output == {}, f"Expected silent at streak=4, got: {output}"
 
     def test_silent_at_streak_6(self):
-        """Streak=6 is not a power of 2, must be silent."""
+        """Streak=6 is not a Fibonacci number, must be silent."""
         output = self._reach_streak(6)
         assert output == {}, f"Expected silent at streak=6, got: {output}"
+
+    def test_silent_at_streak_7(self):
+        """Streak=7 is not a Fibonacci number, must be silent."""
+        output = self._reach_streak(7)
+        assert output == {}, f"Expected silent at streak=7, got: {output}"
 
     def test_advisory_fires_again_after_task_reset(self):
         """After a Task reset, advisory schedule restarts from the beginning."""
@@ -557,6 +558,93 @@ class TestStateFile:
 # Per-project config
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Unblocked tools (never hard-blocked, fire advisory on first call)
+# ---------------------------------------------------------------------------
+
+class TestUnblockedTools:
+    """Unblocked tools are not hard-blocked on first call; instead fire advisory at streak=1."""
+
+    def test_unblocked_tool_not_blocked_on_first_call(self):
+        """Read at streak=0 should NOT get permissionDecision: deny."""
+        output = run_hook("Read", clear_state=True)
+        assert "hookSpecificOutput" in output
+        hook_out = output["hookSpecificOutput"]
+        assert hook_out.get("permissionDecision") != "deny", (
+            "Unblocked tool should not be hard-blocked"
+        )
+        assert "additionalContext" in hook_out, (
+            "Unblocked tool should get advisory instead"
+        )
+
+    def test_unblocked_tool_increments_streak_on_first_call(self):
+        """After Read at streak=0, state should have streak=1 and block_fired=True."""
+        run_hook("Read", clear_state=True)
+        state = get_state()
+        assert state["streak"] == 1, "Unblocked tool should increment streak to 1"
+        assert state["block_fired"] is True, "block_fired should be set to True"
+
+    def test_unblocked_tool_fires_advisory_at_streak_1(self):
+        """The advisory message on first unblocked call should be the distinct streak=1 message."""
+        output = run_hook("Read", clear_state=True)
+        context = output["hookSpecificOutput"].get("additionalContext", "")
+        assert "streak=1" in context, (
+            "Advisory message should reference [streak=1]"
+        )
+        assert "allowed through without blocking" in context, (
+            "Should mention that unblocked tool was allowed through"
+        )
+
+    def test_normal_tool_increments_streak_after_unblocked_first(self):
+        """After Read fires (streak=1, block_fired=True), a Bash call should increment streak to 2."""
+        run_hook("Read", clear_state=True)      # streak=1, block_fired=True
+        run_hook("Bash", clear_state=False)      # streak should → 2
+        state = get_state()
+        assert state["streak"] == 2
+
+    def test_normal_tool_fires_advisory_at_streak_2_after_unblocked(self):
+        """After Read increments to streak=1, Bash should fire advisory at streak=2."""
+        run_hook("Read", clear_state=True)      # streak=1
+        output = run_hook("Bash", clear_state=False)  # streak → 2, advisory fires
+        assert "hookSpecificOutput" in output
+        assert "additionalContext" in output["hookSpecificOutput"]
+
+    def test_unblocked_tool_increments_normally_after_block_fired(self):
+        """After block_fired=True with streak=1, another Read should increment to streak=2."""
+        run_hook("Read", clear_state=True)       # streak=1, block_fired=True
+        run_hook("Read", clear_state=False)      # streak → 2
+        state = get_state()
+        assert state["streak"] == 2
+
+    def test_glob_is_unblocked(self):
+        """Glob should behave same as Read (not blocked on first call)."""
+        output = run_hook("Glob", clear_state=True)
+        assert "hookSpecificOutput" in output
+        assert output["hookSpecificOutput"].get("permissionDecision") != "deny"
+        assert "additionalContext" in output["hookSpecificOutput"]
+
+    def test_grep_is_unblocked(self):
+        """Grep should behave same as Read (not blocked on first call)."""
+        output = run_hook("Grep", clear_state=True)
+        assert "hookSpecificOutput" in output
+        assert output["hookSpecificOutput"].get("permissionDecision") != "deny"
+        assert "additionalContext" in output["hookSpecificOutput"]
+
+    def test_bash_still_blocked(self):
+        """Bash at streak=0 should still get hard block (regression test)."""
+        output = run_hook("Bash", clear_state=True)
+        assert "hookSpecificOutput" in output
+        assert output["hookSpecificOutput"].get("permissionDecision") == "deny"
+
+    def test_task_resets_after_unblocked_streak(self):
+        """After Read increments to streak=1, a Task call should reset to streak=0, block_fired=False."""
+        run_hook("Read", clear_state=True)      # streak=1, block_fired=True
+        run_hook("Task", clear_state=False)      # reset
+        state = get_state()
+        assert state["streak"] == 0
+        assert state["block_fired"] is False
+
+
 class TestProjectConfig:
     """Per-project config file (.claude/delegation-guard.json) support."""
 
@@ -616,6 +704,25 @@ class TestProjectConfig:
 
         output_custom = run_hook("CustomTool", clear_state=False, cwd=str(tmp_path))
         assert output_custom == {}, "Config tool should be exempt"
+
+    def test_project_config_unblocked_tools(self, tmp_path):
+        """Config with unblocked_tools makes those tools behave as unblocked (not blocked on first call)."""
+        # Create config with Edit as unblocked
+        config_dir = tmp_path / ".claude"
+        config_dir.mkdir()
+        config_file = config_dir / "delegation-guard.json"
+        config_file.write_text(json.dumps({"unblocked_tools": ["Edit"]}))
+
+        # Edit should not be hard-blocked on first call
+        output = run_hook("Edit", clear_state=True, cwd=str(tmp_path))
+        assert "hookSpecificOutput" in output
+        hook_out = output["hookSpecificOutput"]
+        assert hook_out.get("permissionDecision") != "deny", (
+            "Config unblocked tool should not be hard-blocked"
+        )
+        assert "additionalContext" in hook_out, (
+            "Config unblocked tool should get advisory instead"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Unblocked tools**: Read, Glob, and Grep skip the hard block on first solo call but count toward the advisory streak. Configurable per-project via `.claude/delegation-guard.json`.
- **Message audit**: All hook messages rewritten based on collaborative review:
  - Hard block is now a nudge with retry hint ("if this is a quick one-off, retry it")
  - Streak=1 has a distinct message acknowledging the unblocked tool was let through
  - Advisory messages use a unified template with escalating label only (reminder -> advisory -> warning -> CRITICAL)
  - Schedule changed from powers-of-2 to Fibonacci (2, 3, 5, 8, 13, 21...)
  - Tool references updated from "Task" to "Agent"

## Test plan

- [x] All 67 tests pass (56 existing + 11 new)
- [ ] Manual: verify hard block message shows retry hint
- [ ] Manual: verify Read/Glob/Grep fire streak=1 advisory instead of blocking
- [ ] Manual: verify advisory fires at streak 3 (not 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
