### PR TITLE
fix(dev-workflow): lower reflect chunk budget + remove high-level scanners [2.3.0]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,7 +107,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.3.0] - 2026-03-08
+
+### Changed
+- Lowered per-chunk token budget from 80K to 20K so scanner agents can read entire chunks in a single Read call (fixes #192)
+- Removed high-level scanner pass — only detail scanners remain, cutting scanner count and improving signal-to-noise ratio (closes #193)
+- Simplified scanner agent instructions (no multi-read needed at 20K chunks)
+
 ## [2.2.0] - 2026-03-08
 
 ### Changed

--- a/plugins/dev-workflow/agents/reflect-scanner.md
+++ b/plugins/dev-workflow/agents/reflect-scanner.md
@@ -23,16 +23,12 @@ You are a transcript scanner for the /reflect skill. You read a pre-processed se
 
 When launched, you will receive:
 1. A file path to read
-2. Whether this is a "detail" scan or "high-level" scan
 
 ### Reading your assigned file
 
-Your chunk files may contain up to ~80,000 tokens. The Read tool returns ~2,000 lines per call but has a token output limit of ~25,000 tokens. You will likely need **multiple Read calls** to read the entire file:
+Your chunk files contain up to ~20,000 tokens and fit in a single Read call.
 
-1. **First read**: `Read(file_path)` — reads the first ~2,000 lines
-2. **Check if truncated**: If the output ends before the file does (the last line number shown is less than the file's total line count), continue reading
-3. **Subsequent reads**: `Read(file_path, offset=<next_line>, limit=2000)` — pick up where you left off
-4. **Repeat** until you have read every line
+- **Read**: `Read(file_path)` — this reads the entire chunk in one call.
 
 **Do NOT begin analysis until you have read the COMPLETE file.** Partial reads will miss findings. After each Read call, note the last line number shown and whether more content remains.
 
@@ -85,12 +81,6 @@ Signals that a pattern was used repeatedly and could be codified.
 | Repeated user guidance | The user giving similar instructions across different parts of the session |
 | Command templates | Similar Bash commands or tool calls differing only in arguments |
 | Manual processes ripe for automation | Multi-step procedures that could be a single skill or hook |
-
-## High-level Scan Variant
-
-If told this is a "high-level" scan, you are scanning a CONDENSED SUMMARY of a session. Focus on the big picture: session flow, major direction changes, recurring themes in user guidance.
-
-Apply checklists 1, 3, and 4 only. Skip Checklist 2 (Execution Failures) — you don't have the tool output detail needed for it.
 
 ## Output Format
 

--- a/plugins/dev-workflow/skills/reflect/SKILL.md
+++ b/plugins/dev-workflow/skills/reflect/SKILL.md
@@ -80,15 +80,6 @@ When deciding where a finding should go, promote as broadly as it's useful:
    )
    ```
 
-   **Example for a high-level scan:**
-   ```
-   Agent(
-     subagent_type: "dev-workflow:reflect-scanner",
-     description: "High-level transcript scan",
-     prompt: "Your assignment: Read the file at /absolute/path/to/.reflect-scan-abc12345-summary.jsonl and perform a HIGH-LEVEL scan."
-   )
-   ```
-
    IMPORTANT: Always use absolute file paths in scanner prompts so scanners can find the files regardless of working directory.
 
 5. After all scanners complete, run the cleanup command from the manifest to remove intermediate files.

--- a/plugins/dev-workflow/skills/reflect/scripts/reflect-filter.py
+++ b/plugins/dev-workflow/skills/reflect/scripts/reflect-filter.py
@@ -515,7 +515,7 @@ def main():
 
         # 5. Size measurement and chunking
         encoding = tiktoken.get_encoding("cl100k_base")
-        max_chunk_tokens = 80_000
+        max_chunk_tokens = 20_000
         overlap_pct = 0.10
         max_line_tokens = int(max_chunk_tokens / (1 + overlap_pct))  # effective_max
         detail_lines = cap_oversized_lines(detail_lines, encoding, max_line_tokens)
@@ -530,7 +530,6 @@ def main():
 
         # 6. Handle chunking
         scanner_jobs = []
-        summary_file = None
 
         if chunks is None:
             # Single file
@@ -551,32 +550,7 @@ def main():
                 if args.mode == "heavy":
                     scanner_jobs.append(("detail", chunk_file, len(chunk_lines)))
 
-            # 7. Summary view (only if chunking)
-            summary_events = [condense_for_summary(e) for e in segment]
-            summary_file = os.path.join(pwd, f".reflect-scan-{nonce_prefix}-summary.jsonl")
-            write_summary_view(summary_events, summary_file)
-            summary_lines = read_detail_lines(summary_file)
-            summary_lines = cap_oversized_lines(summary_lines, encoding, max_line_tokens)
-            summary_tokens = count_lines_tokens(summary_lines, encoding)
-
-            if summary_tokens < max_chunk_tokens * 0.9:
-                scanner_jobs.append(("high-level", summary_file, len(summary_lines)))
-            else:
-                # Chunk the summary too
-                summary_chunks = chunk_detail_view(summary_lines, encoding, max_tokens=max_chunk_tokens, overlap_pct=overlap_pct)
-                for sc_idx, (sc_start, sc_end) in enumerate(summary_chunks):
-                    sc_file = os.path.join(pwd, f".reflect-scan-{nonce_prefix}-summary-{sc_idx}.jsonl")
-                    sc_lines = summary_lines[sc_start:sc_end]
-                    with open(sc_file, "w", encoding="utf-8") as f:
-                        for line in sc_lines:
-                            f.write(line)
-                    scanner_jobs.append(("high-level", sc_file, len(sc_lines)))
-                try:
-                    os.remove(summary_file)
-                except Exception:
-                    pass
-
-            # Clean up original detail file when chunked
+            # 7. Clean up original detail file when chunked
             try:
                 os.remove(detail_file)
             except Exception:


### PR DESCRIPTION
## Summary
- Lowered per-chunk token budget from 80K to 20K so scanner agents can read entire chunks in a single Read call (fixes #192)
- Removed high-level scanner pass — only detail scanners remain, cutting scanner count and improving signal-to-noise ratio (closes #193)
- Simplified scanner agent instructions (no multi-read needed at 20K chunks)

## Test plan
- [x] All 251 tests pass
- [x] Version consistency verified (plugin.json + marketplace.json both 2.3.0)
- [ ] CI passes on PR

---
*Created with assistance from Claude Code*
