### PR TITLE
docs(orchestration): update delegation threshold based on reflect findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This repository contains version-controlled configuration for **Claude Code CLI**.
 
+## Orchestration
+
+Any task requiring more than 1 tool call should be delegated. If you're making sequential solo calls, stop and launch a subagent.
+
 ## Repository Structure
 - `plugins/essentials/` - Hook scripts and tests (published to marketplace)
   - `hooks/` — hook source files


### PR DESCRIPTION
## Summary

- Updates delegation threshold in project CLAUDE.md based on reflect session findings
- Changed guidance from "3 consecutive non-spawn tool calls" to "any task requiring more than 1 tool call"
- Reflects learning that Haiku struggles with sequential solo calls and benefits from subagent delegation

## Related Issues

GitHub issue #197 filed for Haiku scanner robustness in --light mode

---
*Created with assistance from Claude Code*
