### PR TITLE
docs(solve): codify pre-approved spec as Phase 3 skip condition

### DIFF
--- a/plugins/dev-workflow/skills/solve/SKILL.md
+++ b/plugins/dev-workflow/skills/solve/SKILL.md
@@ -84,7 +84,10 @@ fully determined (no sub-choices, no trade-offs worth surfacing), proceed
 directly to Phase 4 and note your approach in passing. If the approach
 contains any implementation sub-choices (even with clear recommendations
 for each), invoke `/consult` via the Skill tool -- never collapse
-sub-choices into a binary confirm/reject.
+sub-choices into a binary confirm/reject. If a detailed spec file was
+collaboratively designed in a prior session and is referenced by the
+issue, treat the issue as well-scoped — skip directly to Phase 4 and note
+the spec path when proceeding.
 
 **Needs design decisions** -- There are open questions about approach,
 trade-offs, or how the solution fits into the existing architecture.


### PR DESCRIPTION
## Summary

Codifies a skip condition for Phase 3 (Scope) in `/solve`: when a detailed spec file was collaboratively designed in a prior session and is referenced by the issue, `/solve` can skip directly to Phase 4 (Plan) and note the spec path.

This came from `/reflect` findings about workflow optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
