### PR TITLE
fix(dev-workflow): fix SubagentStart hook injection for reflect scanners

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,7 +107,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.4.1] - 2026-03-09
+
+### Fixed
+- `/reflect` SubagentStart hook matcher: changed from `"reflect-scanner"` to `"dev-workflow:reflect-scanner"` to match the full subagent_type string the CLI queries with (hook was never firing due to mismatch)
+- `/reflect` filter script: queue file (`.reflect-scan-{nonce}-queue.txt`) is now written for all cases (single-chunk and multi-chunk), not just the multi-chunk branch
+- `/reflect` scanner-inject hook: agent type check changed from `"reflect-scanner"` to `"dev-workflow:reflect-scanner"` for consistency with hook matcher
+
 ## [2.4.0] - 2026-03-09
 
 ### Changed

--- a/plugins/dev-workflow/hooks/hooks.json
+++ b/plugins/dev-workflow/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "SubagentStart": [
       {
-        "matcher": "reflect-scanner",
+        "matcher": "dev-workflow:reflect-scanner",
         "hooks": [
           {
             "type": "command",

--- a/plugins/dev-workflow/hooks/reflect-scanner-inject.py
+++ b/plugins/dev-workflow/hooks/reflect-scanner-inject.py
@@ -28,7 +28,7 @@ def main():
 
     # Check if this is a reflect-scanner agent
     agent_type = input_data.get("agent_type", "")
-    if agent_type != "reflect-scanner":
+    if agent_type != "dev-workflow:reflect-scanner":
         # Not our agent type, pass through
         print("{}", file=sys.stdout)
         return

--- a/plugins/dev-workflow/skills/reflect/scripts/reflect-filter.py
+++ b/plugins/dev-workflow/skills/reflect/scripts/reflect-filter.py
@@ -556,12 +556,13 @@ def main():
             except Exception:
                 pass
 
-            # 7b. Write queue file after chunk files
-            queue_file = os.path.join(pwd, f".reflect-scan-{nonce_prefix}-queue.txt")
-            with open(queue_file, "w") as f:
-                for job_type, filepath, line_count in scanner_jobs:
-                    f.write(filepath + "\n")
+        # 7b. Write queue file for all cases (hook reads from this)
+        queue_file = os.path.join(pwd, f".reflect-scan-{nonce_prefix}-queue.txt")
+        with open(queue_file, "w") as f:
+            for job_type, filepath, line_count in scanner_jobs:
+                f.write(filepath + "\n")
 
+        if chunks is not None:
             # 7c. Post-creation validation
             for chunk_idx, (start_line, end_line) in enumerate(chunks):
                 chunk_file = os.path.join(pwd, f".reflect-scan-{nonce_prefix}-detail-{chunk_idx}.jsonl")


### PR DESCRIPTION
## Summary

Fixes three related bugs in the SubagentStart hook injection pipeline for `/reflect` scanners:

1. **Hook matcher mismatch**: Matcher was `"reflect-scanner"` but CLI queries with full type `"dev-workflow:reflect-scanner"` — hook never fired
2. **Single-chunk queue file**: Queue file (`.reflect-scan-{nonce}-queue.txt`) was only written in the multi-chunk branch, breaking single-chunk transcripts
3. **Agent type check mismatch**: Scanner-inject hook checked against old `"reflect-scanner"` type

## Test plan

- Verify `/reflect` works with both single-chunk and multi-chunk transcripts
- Confirm SubagentStart hook fires for reflect-scanner spawns
- Check that queue files are created and populated correctly for all transcript sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
