### PR TITLE
docs(dev-workflow): clarify scanner count must match manifest job lines

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,7 +107,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.2] - 2026-03-09
+
+### Changed
+- `/reflect` SKILL.md: clarified that scanner count must exactly match manifest job lines to prevent accidentally skipping chunks. Added multi-scanner example to illustrate correct 5-job launch pattern.
+
 ## [2.4.1] - 2026-03-09
 
 ### Fixed

--- a/plugins/dev-workflow/skills/reflect/SKILL.md
+++ b/plugins/dev-workflow/skills/reflect/SKILL.md
@@ -64,20 +64,60 @@ When deciding where a finding should go, promote as broadly as it's useful:
 3. Parse the manifest output. It lists scanner jobs (file paths + scan types) and a cleanup command.
 
 4. Launch scanner agents per the manifest:
-   - For each scanner job line, launch an Agent with `subagent_type: "dev-workflow:reflect-scanner"`
+   - Count the number of lines in the **Scanner Jobs** section. Launch exactly that many Agent calls — one per line, numbered 0 through N-1. Missing a scanner means one chunk goes unscanned. This count must match the number of manifest job lines exactly.
+   - Each agent uses `subagent_type: "dev-workflow:reflect-scanner"`
    - The scanner receives its transcript chunk automatically via the
      SubagentStart hook — do NOT include file paths in the prompt
    - The prompt should contain ONLY a brief assignment identifier
    - For `--light`: pass Haiku model for scanners
    - For default/`--heavy`: pass Sonnet model for scanners
-   - Launch all scanners in parallel where possible
+   - Launch all scanners in a single parallel tool call
 
-   **Example scanner launch:**
+   **Example — 3-job manifest means exactly 3 Agent calls:**
    ```
    Agent(
      subagent_type: "dev-workflow:reflect-scanner",
      description: "Scan transcript chunk 0",
      prompt: "Perform a DETAIL scan on the transcript chunk in your context. You are scanner 0."
+   )
+   Agent(
+     subagent_type: "dev-workflow:reflect-scanner",
+     description: "Scan transcript chunk 1",
+     prompt: "Perform a DETAIL scan on the transcript chunk in your context. You are scanner 1."
+   )
+   Agent(
+     subagent_type: "dev-workflow:reflect-scanner",
+     description: "Scan transcript chunk 2",
+     prompt: "Perform a DETAIL scan on the transcript chunk in your context. You are scanner 2."
+   )
+   ```
+
+   **Example — 5-job manifest means exactly 5 Agent calls (no skipping):**
+   ```
+   Agent(
+     subagent_type: "dev-workflow:reflect-scanner",
+     description: "Scan transcript chunk 0",
+     prompt: "Perform a DETAIL scan on the transcript chunk in your context. You are scanner 0."
+   )
+   Agent(
+     subagent_type: "dev-workflow:reflect-scanner",
+     description: "Scan transcript chunk 1",
+     prompt: "Perform a DETAIL scan on the transcript chunk in your context. You are scanner 1."
+   )
+   Agent(
+     subagent_type: "dev-workflow:reflect-scanner",
+     description: "Scan transcript chunk 2",
+     prompt: "Perform a DETAIL scan on the transcript chunk in your context. You are scanner 2."
+   )
+   Agent(
+     subagent_type: "dev-workflow:reflect-scanner",
+     description: "Scan transcript chunk 3",
+     prompt: "Perform a DETAIL scan on the transcript chunk in your context. You are scanner 3."
+   )
+   Agent(
+     subagent_type: "dev-workflow:reflect-scanner",
+     description: "Scan transcript chunk 4",
+     prompt: "Perform a DETAIL scan on the transcript chunk in your context. You are scanner 4."
    )
    ```
 


### PR DESCRIPTION
Clarifies that the orchestrator must launch exactly N scanners for N manifest job lines. Adds a multi-scanner example to prevent miscounting. Discovered during end-to-end pipeline testing where one scanner was accidentally skipped.
