### PR TITLE
feat(dev-workflow): include scanner count in filter manifest output

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,7 +107,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /consult (structured decisions), /reflect (session retrospective), and /issue (file well-researched issues).",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.4.3] - 2026-03-09
+
+### Changed
+- `/reflect` filter script: Scanner Jobs header now includes explicit count (e.g., "7 scanners to launch") for clearer orchestration
+- `/reflect` SKILL.md: Updated scanner launch instructions to reference the count in the header instead of asking orchestrators to count manifest lines manually
+
 ## [2.4.2] - 2026-03-09
 
 ### Changed

--- a/plugins/dev-workflow/skills/reflect/SKILL.md
+++ b/plugins/dev-workflow/skills/reflect/SKILL.md
@@ -64,7 +64,7 @@ When deciding where a finding should go, promote as broadly as it's useful:
 3. Parse the manifest output. It lists scanner jobs (file paths + scan types) and a cleanup command.
 
 4. Launch scanner agents per the manifest:
-   - Count the number of lines in the **Scanner Jobs** section. Launch exactly that many Agent calls — one per line, numbered 0 through N-1. Missing a scanner means one chunk goes unscanned. This count must match the number of manifest job lines exactly.
+   - The **Scanner Jobs** header includes the exact count (e.g., "7 scanners to launch"). Launch exactly that many Agent calls, numbered 0 through N-1. Missing a scanner means one chunk goes unscanned.
    - Each agent uses `subagent_type: "dev-workflow:reflect-scanner"`
    - The scanner receives its transcript chunk automatically via the
      SubagentStart hook — do NOT include file paths in the prompt

--- a/plugins/dev-workflow/skills/reflect/scripts/reflect-filter.py
+++ b/plugins/dev-workflow/skills/reflect/scripts/reflect-filter.py
@@ -582,7 +582,7 @@ def main():
         print(f"- Detail size: {detail_size} chars ({detail_tokens} tokens)")
         print(f"- Chunking: {chunking_desc}")
         print()
-        print("## Scanner Jobs")
+        print(f"## Scanner Jobs ({len(scanner_jobs)} scanners to launch)")
         for job_type, filepath, line_count in scanner_jobs:
             print(f"{job_type} {filepath} {line_count}")
         print()


### PR DESCRIPTION
The filter script now outputs the scanner count in the Scanner Jobs header (e.g., '7 scanners to launch'). The SKILL.md references this count directly instead of asking the orchestrator to count manifest lines manually. Prevents miscounting when launching parallel scanners.
