### PR TITLE
feat(dev-workflow): add convention-doc re-check to /solve Phase 9 [2.7.0]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,7 +107,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /research (systematic context-building), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution).",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /research (systematic context-building), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution).",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.7.0] - 2026-03-09
+
+### Added
+- `/solve` Phase 9: re-read project convention docs before presenting PR for merge. Catches pre-merge, pre-deploy, and smoke-test requirements that were discovered during exploration but not re-verified before merge.
+
 ## [2.6.0] - 2026-03-09
 
 ### Added

--- a/plugins/dev-workflow/skills/solve/SKILL.md
+++ b/plugins/dev-workflow/skills/solve/SKILL.md
@@ -199,15 +199,21 @@ After code review and CI pass, run a quick check-in before presenting the
 PR for merge. Implementation and review surface decisions and
 considerations that weren't visible during planning:
 
-1. Review the diff (`gh pr diff`) and code review feedback for anything
+1. Re-read project convention documents (CLAUDE.md, README.md,
+   CONTRIBUTING.md, DEVELOPMENT.md, and similar files) in the repo root
+   and in directories containing modified files. Scan for pre-merge,
+   pre-deploy, or smoke-test requirements. Verify each requirement is
+   satisfied before proceeding. If any requirement is unmet, fix it
+   (commit and push) or flag it for the user.
+2. Review the diff (`gh pr diff`) and code review feedback for anything
    that diverged from the original plan or introduced new trade-offs
-2. If there are meaningful decisions or considerations that emerged,
+3. If there are meaningful decisions or considerations that emerged,
    present them to the user via AskUserQuestion:
    - Lead with what changed vs. the plan and why
    - Surface trade-offs the user should know about before merging
    - If everything went exactly to plan with no surprises, briefly
      confirm that and skip the interactive check-in
-3. If the user requests changes, implement them, re-run code review and
+4. If the user requests changes, implement them, re-run code review and
    CI, then return to this phase
 
 ## Phase 10: Present


### PR DESCRIPTION
## Summary

Adds a new step 1 to `/solve` Phase 9 (Pre-merge Check-in) that re-reads project convention documents before presenting the PR for merge. This catches pre-merge, pre-deploy, and smoke-test requirements that were discovered during exploration (Phase 2) but not re-verified at merge time.

## Changes

- **`plugins/dev-workflow/skills/solve/SKILL.md`**: Added new Phase 9 step 1 that re-reads convention docs (CLAUDE.md, README.md, CONTRIBUTING.md, DEVELOPMENT.md, etc.) and verifies pre-merge requirements are satisfied. Renumbered existing steps 1-3 to 2-4.
- **`plugins/dev-workflow/.claude-plugin/plugin.json`**: Bumped version from 2.6.0 to 2.7.0
- **`.claude-plugin/marketplace.json`**: Bumped dev-workflow version from 2.6.0 to 2.7.0
- **`plugins/dev-workflow/CHANGELOG.md`**: Added [2.7.0] entry documenting the new Phase 9 convention check

Closes #181

Generated with Claude Code
