### PR TITLE
fix(delegation-guard): exempt ToolSearch from streak counting [1.3.1]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -71,7 +71,7 @@
     {
       "name": "delegation-guard",
       "description": "PreToolUse hook that encourages main-session delegation to subagents via escalating reminders.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/delegation-guard/.claude-plugin/plugin.json
+++ b/plugins/delegation-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "delegation-guard",
   "description": "PreToolUse hook that encourages main-session delegation to subagents via escalating reminders.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/delegation-guard/CHANGELOG.md
+++ b/plugins/delegation-guard/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.3.1] - 2026-03-09
+
+### Fixed
+
+- Exempt `ToolSearch` from streak counting — it's a prerequisite tool that loads deferred tools and cannot be delegated (#215)
+
 ## [1.3.0] - 2026-03-08
 
 ### Changed

--- a/plugins/delegation-guard/README.md
+++ b/plugins/delegation-guard/README.md
@@ -33,6 +33,7 @@ These tools neither increment nor reset the streak:
 - `AskUserQuestion` — clarification request (not task work)
 - `TaskCreate`, `TaskUpdate`, `TaskGet`, `TaskList` — task list management
 - `EnterPlanMode`, `ExitPlanMode` — planning mode transitions
+- `ToolSearch` — loads deferred tools (prerequisite for other tools; cannot be delegated)
 
 ## Unblocked tools
 

--- a/plugins/delegation-guard/hooks/delegation-guard.py
+++ b/plugins/delegation-guard/hooks/delegation-guard.py
@@ -74,6 +74,7 @@ EXEMPT_TOOLS = {
     "TaskList",
     "EnterPlanMode",
     "ExitPlanMode",
+    "ToolSearch",
 }
 
 # Tools that are never hard-blocked on first call; instead fire advisory at streak=1


### PR DESCRIPTION
## Summary
- Adds `ToolSearch` to the unconditional exempt list in `delegation-guard.py` — it's a prerequisite tool that loads deferred tools and cannot be delegated to subagents
- Bumps version from 1.3.0 to 1.3.1

Closes #215

## Test plan
- [x] All 73 existing delegation-guard tests pass
- [x] `test_exempt_tools_do_not_trigger_block` covers ToolSearch automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)