### PR TITLE
feat(dev-workflow): mandate /consult in /solve Phase 9 [2.8.0]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,7 +107,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /research (systematic context-building), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution).",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /research (systematic context-building), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution).",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.8.0] - 2026-03-09
+
+### Changed
+
+- /solve Phase 9: mandate /consult instead of conditional AskUserQuestion for pre-merge check-in (#216)
+
 ## [2.7.0] - 2026-03-09
 
 ### Added

--- a/plugins/dev-workflow/skills/solve/SKILL.md
+++ b/plugins/dev-workflow/skills/solve/SKILL.md
@@ -207,12 +207,12 @@ considerations that weren't visible during planning:
    (commit and push) or flag it for the user.
 2. Review the diff (`gh pr diff`) and code review feedback for anything
    that diverged from the original plan or introduced new trade-offs
-3. If there are meaningful decisions or considerations that emerged,
-   present them to the user via AskUserQuestion:
-   - Lead with what changed vs. the plan and why
-   - Surface trade-offs the user should know about before merging
-   - If everything went exactly to plan with no surprises, briefly
-     confirm that and skip the interactive check-in
+3. Invoke `/consult` via the Skill tool with whatever decisions,
+   trade-offs, or considerations emerged during implementation and
+   review. /consult will apply its own discipline (recommendations,
+   trade-offs, codebase-informed options). If truly nothing changed
+   vs. the plan, /consult will be quick — the cost of a trivial
+   /consult is far lower than missing a real decision.
 4. If the user requests changes, implement them, re-run code review and
    CI, then return to this phase
 


### PR DESCRIPTION
## Summary
- Replace conditional AskUserQuestion with unconditional /consult invocation in /solve Phase 9 (Pre-merge Check-in)
- Remove the "if meaningful decisions" conditional that let Claude skip the check-in
- The cost of a trivial /consult is far lower than missing a real decision

Closes #216

## Test plan
- [ ] Verify SKILL.md Phase 9 text is updated correctly
- [ ] Confirm version bumped to 2.8.0 in plugin.json and marketplace.json
- [ ] Confirm CHANGELOG.md has new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
