### PR TITLE
feat(dev-workflow): add /spec skill for design-decision specs [2.10.0]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -106,8 +106,8 @@
     },
     {
       "name": "dev-workflow",
-      "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /research (systematic context-building), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution).",
-      "version": "2.9.0",
+      "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /research (systematic context-building), /spec (lightweight specs for design decisions), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution).",
+      "version": "2.10.0",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"
@@ -126,6 +126,7 @@
         "./skills/session",
         "./skills/triage",
         "./skills/research",
+        "./skills/spec",
         "./skills/consult",
         "./skills/reflect",
         "./skills/issue",

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
-  "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /research (systematic context-building), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution).",
-  "version": "2.9.0",
+  "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /research (systematic context-building), /spec (lightweight specs for design decisions), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution).",
+  "version": "2.10.0",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.10.0] - 2026-03-10
+
+### Added
+
+- `/spec` skill for writing lightweight specs on complex issues. Produces a temporary spec file (Problem, Definition of Done, Decisions, Approach) that survives conversation compaction. Auto-invoked by `/solve` Phase 3 when an issue is classified as "Needs design decisions". Also usable standalone.
+- `/solve` Phase 3 now routes "Needs design decisions" issues through `/spec` instead of directly to `/consult`
+- `/solve` Phase 4 uses spec file as primary planning input when available
+- `/solve` Phase 5 deletes spec file in final commit (working artifact, not permanent docs)
+
 ## [2.9.0] - 2026-03-09
 
 ### Changed

--- a/plugins/dev-workflow/README.md
+++ b/plugins/dev-workflow/README.md
@@ -77,6 +77,24 @@ Systematic context-building through parallel research agents. Use before design 
 - Constraints & gotchas: platform limitations, edge cases
 - Adjacent context: related systems, dependencies, integration points
 
+### /spec
+
+Write lightweight specs on complex issues. Produces a temporary spec file that survives conversation compaction and guides planning. Use when an issue requires significant design decisions before implementation.
+
+**When to use:**
+- During `/solve` for issues classified as "Needs design decisions"
+- Standalone when you need to document design trade-offs
+- Before major refactors or architectural changes
+- When multiple implementation approaches are viable
+
+**What it does:** Generates a structured temporary spec file with Problem statement, Definition of Done, key Decisions, and Approach. The spec is saved to the working directory, used by `/solve` Phase 4 for planning, and deleted in Phase 5 as a working artifact (not permanent documentation).
+
+**Spec sections:**
+- Problem: clear statement of what needs solving
+- Definition of Done: acceptance criteria and success metrics
+- Decisions: key design trade-offs and choices made
+- Approach: implementation strategy and phases
+
 ### /consult
 
 Collaborative decision-making with the user. Presents curated, high-leverage questions that demonstrate deep codebase understanding. Use any time you need the user's input on design decisions.

--- a/plugins/dev-workflow/skills/solve/SKILL.md
+++ b/plugins/dev-workflow/skills/solve/SKILL.md
@@ -84,27 +84,23 @@ fully determined (no sub-choices, no trade-offs worth surfacing), proceed
 directly to Phase 4 and note your approach in passing. If the approach
 contains any implementation sub-choices (even with clear recommendations
 for each), invoke `/consult` via the Skill tool -- never collapse
-sub-choices into a binary confirm/reject. If a detailed spec file was
-collaboratively designed in a prior session and is referenced by the
-issue, treat the issue as well-scoped — skip directly to Phase 4 and note
-the spec path when proceeding.
+sub-choices into a binary confirm/reject. If a spec file produced by /spec
+(or collaboratively designed in a prior session) already exists and is
+referenced by the issue, treat the issue as well-scoped — skip directly to
+Phase 4 and note the spec path when proceeding.
 
 **Needs design decisions** -- There are open questions about approach,
 trade-offs, or how the solution fits into the existing architecture.
-Invoke `/consult` via the Skill tool to handle this phase -- do not call
-AskUserQuestion directly. The Skill tool ensures the full consult discipline
-is applied:
-
-- Present only high-leverage decisions where the user's input changes the
-  outcome
-- Lead with a recommendation, but surface the weakest parts of that
-  recommendation
-- Options must demonstrate deep codebase understanding -- never generic
-- Group related questions (up to 4) into a single AskUserQuestion call
-- Progress from high-level architectural decisions down to implementation
-  details
+Invoke `/spec` via the Skill tool. /spec handles Definition of Done
+confirmation, /consult rounds for design decisions, and writes a spec file.
+Do not invoke `/consult` directly — /spec manages the design workflow and
+produces a durable artifact.
 
 ## Phase 4: Plan
+
+If /spec produced a spec file in Phase 3, use it as the primary input for
+planning. The spec's Definition of Done defines acceptance criteria; the
+Approach section frames the design direction.
 
 Write a concrete implementation plan:
 
@@ -134,6 +130,10 @@ Execute the approved plan:
    - Has a clear title (under 72 characters)
    - Summarizes the changes in the body
    - Includes `Closes #N` for each issue being resolved
+
+If a spec file was created by /spec, delete it in the final commit before
+creating the PR. Spec files are working artifacts, not permanent
+documentation.
 
 ## Phase 6: Verify
 

--- a/plugins/dev-workflow/skills/spec/SKILL.md
+++ b/plugins/dev-workflow/skills/spec/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: spec
+description: >-
+  Write a lightweight spec for issues that need design decisions. Produces a
+  temporary spec file capturing Problem, Definition of Done, Decisions, and
+  Approach. Invoked automatically by /solve for complex issues, or standalone
+  with an issue number. Spec files are working artifacts deleted after merge.
+---
+
+# Spec
+
+Write a lightweight spec file for issues requiring design decisions.
+Produces a durable artifact that survives conversation compaction and
+guides implementation.
+
+## Arguments
+
+Parse issue references from arguments (numbers, #-prefixed, or URLs).
+Normalize to issue numbers.
+
+## When invoked standalone
+
+If invoked outside /solve (no prior exploration context), run a quick
+intake and exploration phase:
+
+1. Fetch the issue with `gh`
+2. Launch an Explore subagent to understand relevant code and patterns
+3. Then proceed to the spec workflow below
+
+If invoked by /solve, exploration is already done — proceed directly.
+
+## Spec Workflow
+
+### Step 1: Draft Definition of Done
+
+Before exploring approaches or making design decisions, lock in what
+success looks like. This prevents goal drift during brainstorming.
+
+1. Synthesize a Definition of Done from the issue body, comments, and
+   exploration findings
+2. Present the draft DoD to the user via `AskUserQuestion` for
+   confirmation/refinement
+3. The DoD should be concrete and verifiable — "the user can..." or
+   "the system does..." statements, not vague goals
+
+Do not proceed until the DoD is confirmed.
+
+### Step 2: Resolve Design Decisions
+
+Invoke `/consult` (via the Skill tool) to resolve open design questions.
+`/consult` handles recommendation-led, codebase-informed questions with
+the user.
+
+If the issue has no open design questions (rare for issues routed here),
+skip this step.
+
+### Step 3: Write Spec File
+
+Write the spec to `SPEC-<issue-number>.md` at the repository root.
+
+Template:
+
+```markdown
+# Spec: <Issue Title> (#<number>)
+
+## Problem
+
+<What the issue is solving — 2-3 sentences from the issue body>
+
+## Definition of Done
+
+<Confirmed DoD from Step 1 — bulleted list of concrete criteria>
+
+## Decisions
+
+<Each design decision resolved in Step 2, with the chosen option and
+brief rationale. If no decisions were needed, note "No open design
+questions — approach was clear from exploration.">
+
+## Approach
+
+<The chosen design direction, synthesizing the DoD and decisions into
+a coherent plan. Component-level detail — what changes where and why.
+NOT task-level implementation steps (that's /solve Phase 4's job).>
+```
+
+Commit the spec file to the current branch with message:
+
+```
+docs: add spec for #<number>
+```
+
+### Step 4: Return
+
+Report the spec file path to the caller. If invoked by /solve, /solve
+will use this as input for Phase 4 (Plan). The spec file should be
+deleted in the final commit before the PR is presented.
+
+## Guidelines
+
+- The spec is a working artifact, not permanent documentation. Keep it
+  concise — a page or less for most issues.
+- Definition of Done is the anchor. If design discussion drifts, return
+  to the DoD.
+- Don't duplicate `/consult`'s job. Invoke `/consult` for design decisions
+  rather than running your own `AskUserQuestion` for design choices.
+- The spec captures WHAT and WHY at component level. Implementation
+  details (task breakdown, file-by-file changes) belong in /solve Phase 4.
+- If the issue is simple enough that the spec would just restate the
+  issue body, say so and skip spec generation. Not every "needs design
+  decisions" issue needs a full spec — sometimes one `/consult` round is
+  enough and the decisions can be noted inline.


### PR DESCRIPTION
## Summary

- Add `/spec` skill for writing lightweight design specs on complex issues
- `/solve` Phase 3 now routes "Needs design decisions" issues through `/spec` instead of directly to `/consult`
- Spec files capture Problem, Definition of Done, Decisions, and Approach in a temp file that survives compaction
- Inspired by ed3d-plugins' plan-and-execute pattern, especially the "Definition of Done before brainstorming" principle

## Test plan

- [ ] Invoke `/spec 182` standalone to verify it runs the full workflow
- [ ] Invoke `/solve` on an issue classified as "Needs design decisions" and verify it routes to `/spec`
- [ ] Verify spec file is created at repo root as `SPEC-<number>.md`
- [ ] Verify spec file is deleted in final commit

Closes #182

Generated with [Claude Code](https://claude.com/claude-code)
