### PR TITLE
feat(dev-workflow): clarify skill architecture and add /research routing [2.11.0] (#222) (#176)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -106,8 +106,8 @@
     },
     {
       "name": "dev-workflow",
-      "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /research (systematic context-building), /spec (lightweight specs for design decisions), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution).",
-      "version": "2.10.0",
+      "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR with conditional routing), /code-review (multi-agent PR review), /research (systematic context-building), /spec (lightweight specs for design decisions), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution). Concern-oriented design with conditional skill routing.",
+      "version": "2.11.0",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /research (systematic context-building), /spec (lightweight specs for design decisions), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution).",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.11.0] - 2026-03-10
+
+### Added
+- /solve Phase 2 now conditionally invokes /research for issues involving unfamiliar APIs, external systems, or explicit investigation needs
+- Architecture overview section in README documenting skill dependency graph and design philosophy
+
+### Changed
+- /solve Phase 3 routing criteria tightened with concrete, checkable conditions (replaces vague "obvious" and "low-risk" language)
+- /consult SKILL.md documents its role as the reusable decision-making primitive
+- /spec SKILL.md documents its relationship to /consult and when /solve routes to each
+- dev-workflow description updated to emphasize concern-oriented design with conditional routing
+
 ## [2.10.0] - 2026-03-10
 
 ### Added

--- a/plugins/dev-workflow/README.md
+++ b/plugins/dev-workflow/README.md
@@ -134,6 +134,38 @@ Files a well-researched GitHub issue from a brief description. Use when asked to
 - Drafts a structured issue with Problem, Current state, and Desired outcome sections
 - Files via `gh issue create` (or body file for multi-line bodies)
 
+## Architecture
+
+### Design Philosophy
+
+Skills are **concern-oriented** — each solves one problem — with **conditional routing**, not pipeline-oriented. This keeps skills reusable: `/consult` can be invoked standalone, by `/solve` for scoping decisions, or by `/spec` for design questions. Similarly, `/research` is optionally invoked by `/solve` Phase 2 when the issue involves unfamiliar APIs, external systems, or explicit investigation needs.
+
+### Skill Dependency Graph
+
+```
+/session → /triage → /solve → /reflect
+                       ↓
+              /spec ←→ /consult
+                       ↓
+                   /code-review
+```
+
+- `/session` coordinates the full dev lifecycle: triage, solve, reflect
+- `/solve` assesses issue complexity and routes to `/spec` (for design-heavy issues) or direct implementation
+- `/spec` wraps `/consult` to produce durable spec artifacts; `/consult` provides reusable decision-making
+- `/solve` optionally invokes `/research` in Phase 2 for unfamiliar territory
+- `/code-review` is the final approval gate (standalone or called by `/solve` Phase 8)
+
+### Routing Model
+
+`/solve` classifies the issue on intake and conditionally invokes the right skill:
+- **Well-scoped issues** (clear acceptance criteria, determined approach) → skip directly to implementation
+- **Issues needing design decisions** (multiple approaches, significant trade-offs) → route through `/spec` + `/consult`
+- **Unfamiliar territory** (unknown APIs, external systems) → invoke `/research` in Phase 2
+- **Complex scoping** (unclear boundaries, ambiguous requirements) → invoke `/consult` to refine the problem
+
+This is different from pipeline models (like ed3d-plan-and-execute) where every issue flows through design → plan → execute sequentially. The conditional routing keeps the common path fast.
+
 ## Agents
 
 ### worktree-implementor

--- a/plugins/dev-workflow/skills/consult/SKILL.md
+++ b/plugins/dev-workflow/skills/consult/SKILL.md
@@ -121,3 +121,19 @@ Acknowledge their choice briefly and adapt your plan. If they chose
 something you didn't recommend, adjust without resistance -- they have
 context you don't. If their choice invalidates downstream decisions
 you were going to ask about, update those before presenting them.
+
+## Role in the skill collection
+
+`/consult` is the **reusable decision-making primitive** in the dev-workflow
+plugin. It handles structured user interaction for design choices — any skill
+that needs collaborative decisions should invoke `/consult` rather than
+calling `AskUserQuestion` directly for design questions.
+
+Current consumers:
+- `/solve` — Phases 3 (well-scoped sub-choices), 4 (plan approval with
+  design choices), and 9 (post-implementation trade-offs)
+- `/spec` — Step 2 (resolving design decisions within the spec workflow)
+
+`/consult` is deliberately stateless and artifact-free. It asks questions,
+gets answers, and returns. Skills that need durable artifacts (like spec
+files) wrap `/consult` rather than extending it.

--- a/plugins/dev-workflow/skills/solve/SKILL.md
+++ b/plugins/dev-workflow/skills/solve/SKILL.md
@@ -58,7 +58,13 @@ research directly:
    When the codebase has infrastructure, plugins, or related subsystems,
    check whether an established pattern already handles the problem you're
    solving. Adopting an existing pattern is preferable to reinventing it.
-6. **Follow every link in the issue.** If the issue references papers,
+6. **Invoke `/research` for unfamiliar territory.** If the issue involves
+   external APIs, systems you haven't worked with in this codebase, or
+   explicitly calls for investigation, invoke `/research` via the Skill
+   tool to systematically map the design space before proceeding. Most
+   issues won't need this — targeted exploration (steps 1-5) is sufficient
+   when the domain is familiar.
+7. **Follow every link in the issue.** If the issue references papers,
    docs, blog posts, or external resources, fetch and read them with
    WebFetch before moving on. If it references specific code or files,
    read them. If it says "investigation required," complete that
@@ -74,13 +80,14 @@ and signal that you haven't done the work.
 
 Triage the issue(s) into one of three categories:
 
-**Trivial** -- The fix is obvious, mechanical, and low-risk (typo, config
-change, single-line fix). Skip directly to Phase 4 without user
-interaction.
+**Trivial** -- ALL of these are true: (1) the fix touches 1-2 files,
+(2) the change is mechanical (typo, config value, version bump, rename),
+(3) no behavioral change that could break callers. Skip directly to
+Phase 4 without user interaction.
 
-**Well-scoped** -- The issue clearly describes what to build and the
-implementation path is clear from your exploration. If the approach is
-fully determined (no sub-choices, no trade-offs worth surfacing), proceed
+**Well-scoped** -- The issue describes what to build and the exploration
+in Phase 2 reveals a clear implementation path. If the approach is fully
+determined (no sub-choices, no trade-offs worth surfacing), proceed
 directly to Phase 4 and note your approach in passing. If the approach
 contains any implementation sub-choices (even with clear recommendations
 for each), invoke `/consult` via the Skill tool -- never collapse
@@ -89,12 +96,15 @@ sub-choices into a binary confirm/reject. If a spec file produced by /spec
 referenced by the issue, treat the issue as well-scoped — skip directly to
 Phase 4 and note the spec path when proceeding.
 
-**Needs design decisions** -- There are open questions about approach,
-trade-offs, or how the solution fits into the existing architecture.
-Invoke `/spec` via the Skill tool. /spec handles Definition of Done
-confirmation, /consult rounds for design decisions, and writes a spec file.
-Do not invoke `/consult` directly — /spec manages the design workflow and
-produces a durable artifact.
+**Needs design decisions** -- ANY of these are true: (1) the issue has
+open questions about approach with multiple viable options, (2) the
+solution involves trade-offs the user should weigh, (3) the change
+affects architecture or interfaces that other code depends on, (4) you
+cannot write a concrete plan without making assumptions the user should
+validate. Invoke `/spec` via the Skill tool. /spec handles Definition of
+Done confirmation, /consult rounds for design decisions, and writes a spec
+file. Do not invoke `/consult` directly — /spec manages the design workflow
+and produces a durable artifact.
 
 ## Phase 4: Plan
 

--- a/plugins/dev-workflow/skills/spec/SKILL.md
+++ b/plugins/dev-workflow/skills/spec/SKILL.md
@@ -110,3 +110,23 @@ deleted in the final commit before the PR is presented.
   issue body, say so and skip spec generation. Not every "needs design
   decisions" issue needs a full spec — sometimes one `/consult` round is
   enough and the decisions can be noted inline.
+
+## Role in the skill collection
+
+`/spec` is a **workflow that produces a durable artifact** (the spec file).
+It uses `/consult` internally for design decisions but adds:
+
+- **Definition of Done** — locks in success criteria before exploring
+  approaches (prevents goal drift)
+- **Spec file** — a working document that survives context compaction and
+  guides implementation
+
+The relationship: `/consult` is a reusable decision primitive (stateless,
+artifact-free). `/spec` is a workflow that wraps `/consult` and produces a
+file. This is analogous to a function vs. a program that calls it.
+
+**When /solve routes to /spec vs /consult directly:**
+- `/spec` — "Needs design decisions" issues where the complexity warrants
+  a durable artifact (DoD + decisions + approach captured in a file)
+- `/consult` — Well-scoped issues with implementation sub-choices, or
+  post-implementation trade-offs in Phase 9 (decisions don't need a file)


### PR DESCRIPTION
## Summary

- Tightened `/solve` Phase 3 routing criteria from vague language ("obvious", "low-risk") to concrete, checkable conditions for each category (Trivial, Well-scoped, Needs design decisions)
- Added conditional `/research` invocation to Phase 2 for issues involving unfamiliar APIs, external systems, or explicit investigation needs
- Documented `/consult` as the reusable decision-making primitive in the skill collection with current consumers
- Documented `/spec`'s role as a workflow wrapper around `/consult` that produces durable spec artifacts; clarified when `/solve` routes to each
- Added Architecture section to dev-workflow README with skill dependency graph and routing model explaining the conditional-routing philosophy

Closes #222
Closes #176

## Test plan

- [x] Verify all 7 changed files have correct content per the diff
- [x] Confirm version numbers match (both 2.11.0 in plugin.json and marketplace.json)
- [x] Verify CHANGELOG.md has [2.11.0] entry with appropriate sections
- [x] Commit created with proper message format and co-authored-by attribution
- [x] Branch pushed successfully to origin

## Notes

This clarifies the skill architecture without breaking changes — all skills remain backward-compatible. The added `/research` invocation is conditional (most issues won't trigger it), and the routing criteria changes make `/solve` more predictable for users while maintaining the same behavior on the common path.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
