### PR TITLE
feat(dev-workflow): add impact analysis phase to /solve [2.12.0]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -107,7 +107,7 @@
     {
       "name": "dev-workflow",
       "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR with conditional routing), /code-review (multi-agent PR review), /research (systematic context-building), /spec (lightweight specs for design decisions), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution). Concern-oriented design with conditional skill routing.",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "description": "Development workflow skills and agents for GitHub-based repos. Includes /session (full dev lifecycle), /triage (issue prioritization), /solve (issue-to-PR), /code-review (multi-agent PR review), /research (systematic context-building), /spec (lightweight specs for design decisions), /consult (structured decisions), /reflect (session retrospective), /issue (file well-researched issues), and the worktree-implementor agent (isolated worktree execution).",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/dev-workflow/CHANGELOG.md
+++ b/plugins/dev-workflow/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.12.0] - 2026-03-12
+
+### Added
+- `/solve` Phase 9 (Impact Analysis): checks dependent issues, scans for ripple effects (docs, shared code, config, versions), and categorizes findings as fix-in-PR, follow-up issue, or no action. Catches project-wide impact that code review and CI miss.
+
+### Changed
+- `/solve` phases renumbered: Pre-merge Check-in is now Phase 10 (was 9), Present is now Phase 11 (was 10)
+- `/solve` Phase 10 (Pre-merge Check-in): /consult now includes impact analysis findings alongside implementation and review considerations
+- `/consult` consumer documentation updated with new /solve phase numbers
+
 ## [2.11.0] - 2026-03-10
 
 ### Added

--- a/plugins/dev-workflow/README.md
+++ b/plugins/dev-workflow/README.md
@@ -39,7 +39,7 @@ Turns one or more GitHub issues into a reviewed pull request. Use when asked to 
 - `--light` - Use the Haiku-first checklist review instead of the default single-Sonnet agent
 - `--heavy` - Use the full multi-agent Opus review instead of the default single-Sonnet agent
 
-**Phases:** Intake → Explore → Scope (with `/consult` if needed) → Plan → Implement → Verify → Review → Confirm CI → Pre-merge check-in → Present
+**Phases:** Intake → Explore → Scope (with `/consult` if needed) → Plan → Implement → Verify → Review → Confirm CI → Impact analysis → Pre-merge check-in → Present
 
 ### /code-review
 

--- a/plugins/dev-workflow/skills/consult/SKILL.md
+++ b/plugins/dev-workflow/skills/consult/SKILL.md
@@ -131,7 +131,7 @@ calling `AskUserQuestion` directly for design questions.
 
 Current consumers:
 - `/solve` — Phases 3 (well-scoped sub-choices), 4 (plan approval with
-  design choices), and 9 (post-implementation trade-offs)
+  design choices), and 10 (post-implementation trade-offs)
 - `/spec` — Step 2 (resolving design decisions within the spec workflow)
 
 `/consult` is deliberately stateless and artifact-free. It asks questions,

--- a/plugins/dev-workflow/skills/solve/SKILL.md
+++ b/plugins/dev-workflow/skills/solve/SKILL.md
@@ -203,9 +203,47 @@ loop, but the CI run is the source of truth.
 
 If the project has no CI, skip this phase.
 
-## Phase 9: Pre-merge Check-in
+## Phase 9: Impact Analysis
 
-After code review and CI pass, run a quick check-in before presenting the
+Before the pre-merge check-in, assess the broader impact of the change
+on the project. Code review checks the diff; CI runs existing tests.
+This phase catches what both miss: ripple effects beyond the changed
+files.
+
+1. **Check dependent issues.** Run `gh issue list --search "linked:<issue>"`
+   or search for issues that reference the one being solved. For each
+   related issue:
+   - Has this change unblocked it, partially addressed it, or
+     invalidated its assumptions?
+   - Does its description or acceptance criteria need updating?
+   - Note findings for /consult in Phase 10.
+
+2. **Scan for ripple effects.** Review the PR diff and check whether any
+   of these need updates:
+   - Documentation (README, CLAUDE.md, CONTRIBUTING.md, inline docs)
+     that references changed behavior, interfaces, or file paths
+   - Shared code (utilities, types, constants) consumed by files
+     outside the PR's diff
+   - Configuration files, CI workflows, or build scripts affected by
+     renamed or restructured code
+   - Version strings, changelogs, or marketplace metadata that the
+     project's conventions require updating alongside code changes
+
+3. **Collect findings.** Categorize each finding as:
+   - **Fix in this PR** — small enough to address now (doc updates,
+     version bumps, issue description edits)
+   - **File follow-up issue** — too large for this PR but should be
+     tracked
+   - **No action needed** — noted but not actionable
+
+   Apply "fix in this PR" items immediately (commit and push). For
+   "file follow-up issue" items, draft issue descriptions to present
+   in Phase 10. If no actionable findings emerge, proceed directly
+   to Phase 10 — do not fabricate issues.
+
+## Phase 10: Pre-merge Check-in
+
+After code review, CI, and impact analysis, run a quick check-in before presenting the
 PR for merge. Implementation and review surface decisions and
 considerations that weren't visible during planning:
 
@@ -218,15 +256,15 @@ considerations that weren't visible during planning:
 2. Review the diff (`gh pr diff`) and code review feedback for anything
    that diverged from the original plan or introduced new trade-offs
 3. Invoke `/consult` via the Skill tool with whatever decisions,
-   trade-offs, or considerations emerged during implementation and
-   review. /consult will apply its own discipline (recommendations,
+   trade-offs, or considerations emerged during implementation,
+   review, and impact analysis. /consult will apply its own discipline (recommendations,
    trade-offs, codebase-informed options). If truly nothing changed
    vs. the plan, /consult will be quick — the cost of a trivial
    /consult is far lower than missing a real decision.
 4. If the user requests changes, implement them, re-run code review and
    CI, then return to this phase
 
-## Phase 10: Present
+## Phase 11: Present
 
 Give the user:
 


### PR DESCRIPTION
## Summary
- Adds Phase 9 (Impact Analysis) to `/solve` — checks dependent issues, scans for ripple effects (docs, shared code, config, versions), and categorizes findings as fix-in-PR, follow-up issue, or no action
- Renumbers Pre-merge Check-in to Phase 10, Present to Phase 11
- Impact analysis findings feed into the existing `/consult` invocation in Phase 10

Closes #178

## Test plan
- [ ] Verify SKILL.md phase numbering is consistent (no gaps, no duplicates)
- [ ] Verify cross-references in /consult SKILL.md match new phase numbers
- [ ] Verify plugin.json and marketplace.json versions both read 2.12.0
- [ ] Verify CHANGELOG entry is present and correctly dated
- [ ] Verify README phase list includes "Impact analysis"

Generated with [Claude Code](https://claude.com/claude-code)
