### PR TITLE
fix(haiku-enforce): preserve original tool input in updatedInput [1.0.1]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -118,7 +118,7 @@
     {
       "name": "haiku-enforce",
       "description": "PreToolUse hook that enforces Haiku model for all subagent launches via updatedInput.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Jython1415",
         "url": "https://github.com/Jython1415"

--- a/plugins/haiku-enforce/.claude-plugin/plugin.json
+++ b/plugins/haiku-enforce/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "haiku-enforce",
   "description": "PreToolUse hook that enforces Haiku model for all subagent launches via updatedInput.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Jython1415",
     "url": "https://github.com/Jython1415"

--- a/plugins/haiku-enforce/CHANGELOG.md
+++ b/plugins/haiku-enforce/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.1] - 2026-03-25
+
+### Fixed
+- `updatedInput` now preserves all original tool input fields alongside the model override. Previously only `{"model": "haiku"}` was returned, stripping prompt, description, and other fields, which crashed the Agent tool.
+
 ## [1.0.0] - 2026-03-05
 
 ### Added

--- a/plugins/haiku-enforce/hooks/haiku-enforce.py
+++ b/plugins/haiku-enforce/hooks/haiku-enforce.py
@@ -31,14 +31,13 @@ def main():
             print("{}")
             sys.exit(0)
 
+        original_input = input_data.get("tool_input", {})
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
                 "permissionDecision": "allow",
                 "permissionDecisionReason": "Haiku model enforced by haiku-enforce plugin",
-                "updatedInput": {
-                    "model": "haiku"
-                },
+                "updatedInput": {**original_input, "model": "haiku"},
                 "additionalContext": (
                     "haiku-enforce: This Agent call has been overridden to use the Haiku model. "
                     "To remove this constraint, uninstall the haiku-enforce plugin."

--- a/plugins/haiku-enforce/tests/test_haiku_enforce.py
+++ b/plugins/haiku-enforce/tests/test_haiku_enforce.py
@@ -91,11 +91,13 @@ class TestAgentOverride:
         hook_out = output["hookSpecificOutput"]
         assert hook_out["updatedInput"]["model"] == "haiku"
 
-    def test_updated_input_only_contains_model(self):
-        """updatedInput must only contain the model field (merge, don't replace)."""
-        output = run_hook("Agent", tool_input={"prompt": "test", "description": "test"})
+    def test_updated_input_preserves_original_fields(self):
+        """updatedInput must preserve all original tool_input fields alongside model override."""
+        output = run_hook("Agent", tool_input={"prompt": "test prompt", "description": "test desc"})
         hook_out = output["hookSpecificOutput"]
-        assert hook_out["updatedInput"] == {"model": "haiku"}
+        assert hook_out["updatedInput"]["model"] == "haiku"
+        assert hook_out["updatedInput"]["prompt"] == "test prompt"
+        assert hook_out["updatedInput"]["description"] == "test desc"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix `updatedInput` in haiku-enforce hook to preserve all original tool input fields alongside the model override
- Previously `updatedInput` returned only `{"model": "haiku"}`, which caused Claude Code to strip the prompt and other fields from Agent tool calls, crashing with `undefined is not an object (evaluating 'K.length')`
- Now merges original `tool_input` with model override: `{**original_input, "model": "haiku"}`

## Test plan

- [x] Updated `test_updated_input_only_contains_model` → `test_updated_input_preserves_original_fields` to verify original fields are preserved
- [x] All 16 haiku-enforce tests pass
- [x] Full test suite (277 tests) passes
- [x] Manual verification: hook output includes prompt, description, and model override

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
